### PR TITLE
ci: add baseline monorepo quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.6
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck frontend
+        run: bun run check
+
+      - name: Build frontend
+        run: bun run build
+
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            backend/uv.lock
+            backend/**/*.toml
+
+      - name: Sync backend workspace
+        run: uv sync --all-packages --frozen
+
+      - name: Lint backend
+        run: uv run --frozen ruff check .
+
+      - name: Test backend
+        run: uv run --frozen pytest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help tooling-install frontend-install frontend-dev backend-sync backend-lock backend-api-dev backend-worker-run dev-services-up dev-services-down dev-services-reset dev-services-logs
+.PHONY: help tooling-install frontend-install frontend-check frontend-build frontend-dev backend-sync backend-lock backend-lint backend-test backend-api-dev backend-worker-run ci dev-services-up dev-services-down dev-services-reset dev-services-logs
 
 help:
 	@printf "%s\n" \
@@ -10,11 +10,16 @@ help:
 	"  make dev-services-logs Tail logs for the local development services" \
 	"  make tooling-install   Install repo-level tooling such as Husky and commitlint" \
 	"  make frontend-install  Install repo tooling and Bun dependencies for the frontend workspace" \
+	"  make frontend-check    Typecheck the frontend workspace" \
+	"  make frontend-build    Build the frontend workspace" \
 	"  make frontend-dev      Run the frontend workspace dev script" \
 	"  make backend-sync      Sync the uv backend workspace" \
 	"  make backend-lock      Refresh the backend uv lockfile" \
+	"  make backend-lint      Lint the backend workspace with Ruff" \
+	"  make backend-test      Run backend pytest tests" \
 	"  make backend-api-dev   Run the FastAPI backend app with reload" \
-	"  make backend-worker-run Run the worker bootstrap command"
+	"  make backend-worker-run Run the worker bootstrap command" \
+	"  make ci                Run the baseline local CI quality gates"
 
 dev-services-up:
 	docker compose up -d
@@ -34,6 +39,12 @@ tooling-install:
 frontend-install: tooling-install
 	cd frontend && bun install
 
+frontend-check:
+	cd frontend && bun run check
+
+frontend-build:
+	cd frontend && bun run build
+
 frontend-dev:
 	cd frontend && bun run dev
 
@@ -43,8 +54,16 @@ backend-sync:
 backend-lock:
 	cd backend && uv lock
 
+backend-lint:
+	cd backend && uv run ruff check .
+
+backend-test:
+	cd backend && uv run pytest
+
 backend-api-dev:
 	cd backend && uv run --package athena uvicorn optimark_athena.app:app --reload
 
 backend-worker-run:
 	cd backend && uv run --package hermes hermes-worker
+
+ci: frontend-check frontend-build backend-lint backend-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help tooling-install frontend-install frontend-check frontend-build frontend-dev backend-sync backend-lock backend-lint backend-test backend-api-dev backend-worker-run ci dev-services-up dev-services-down dev-services-reset dev-services-logs
+.PHONY: help tooling-install frontend-install frontend-ci-install frontend-check frontend-build frontend-dev backend-sync backend-ci-sync backend-lock backend-lint backend-test backend-api-dev backend-worker-run ci dev-services-up dev-services-down dev-services-reset dev-services-logs
 
 help:
 	@printf "%s\n" \
@@ -10,10 +10,12 @@ help:
 	"  make dev-services-logs Tail logs for the local development services" \
 	"  make tooling-install   Install repo-level tooling such as Husky and commitlint" \
 	"  make frontend-install  Install repo tooling and Bun dependencies for the frontend workspace" \
+	"  make frontend-ci-install Install frontend dependencies with a frozen lockfile" \
 	"  make frontend-check    Typecheck the frontend workspace" \
 	"  make frontend-build    Build the frontend workspace" \
 	"  make frontend-dev      Run the frontend workspace dev script" \
 	"  make backend-sync      Sync the uv backend workspace" \
+	"  make backend-ci-sync   Sync the uv backend workspace with the frozen lockfile" \
 	"  make backend-lock      Refresh the backend uv lockfile" \
 	"  make backend-lint      Lint the backend workspace with Ruff" \
 	"  make backend-test      Run backend pytest tests" \
@@ -39,6 +41,9 @@ tooling-install:
 frontend-install: tooling-install
 	cd frontend && bun install
 
+frontend-ci-install:
+	cd frontend && bun install --frozen-lockfile
+
 frontend-check:
 	cd frontend && bun run check
 
@@ -51,14 +56,17 @@ frontend-dev:
 backend-sync:
 	cd backend && uv sync --all-packages
 
+backend-ci-sync:
+	cd backend && uv sync --all-packages --frozen
+
 backend-lock:
 	cd backend && uv lock
 
 backend-lint:
-	cd backend && uv run ruff check .
+	cd backend && uv run --frozen ruff check .
 
 backend-test:
-	cd backend && uv run pytest
+	cd backend && uv run --frozen pytest
 
 backend-api-dev:
 	cd backend && uv run --package athena uvicorn optimark_athena.app:app --reload
@@ -66,4 +74,10 @@ backend-api-dev:
 backend-worker-run:
 	cd backend && uv run --package hermes hermes-worker
 
-ci: frontend-check frontend-build backend-lint backend-test
+ci:
+	$(MAKE) frontend-ci-install
+	$(MAKE) frontend-check
+	$(MAKE) frontend-build
+	$(MAKE) backend-ci-sync
+	$(MAKE) backend-lint
+	$(MAKE) backend-test

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The backend workspace keeps readable directory names while using themed uv packa
 make help
 cp .env.example .env
 make dev-services-up
+make ci
 make tooling-install
 make frontend-install
-make ci
 make frontend-dev
 make backend-sync
 make backend-api-dev
@@ -111,11 +111,13 @@ The baseline CI workflow runs on pushes to `main` and pull requests. It validate
 - frontend dependency install, typecheck, and build
 - backend uv sync, Ruff linting, and pytest smoke tests
 
-Run the same checks locally with:
+Run the same setup and checks locally with one command:
 
 ```sh
 make ci
 ```
+
+`make ci` installs frontend dependencies with `--frozen-lockfile`, syncs the backend workspace with `--frozen`, and then runs the same frontend and backend quality gates as GitHub Actions.
 
 ## Local development services
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ cp .env.example .env
 make dev-services-up
 make tooling-install
 make frontend-install
+make ci
 make frontend-dev
 make backend-sync
 make backend-api-dev
@@ -102,6 +103,19 @@ make backend-worker-run
 ```
 
 The frontend now boots a real routed SPA with a shared workspace shell, while the backend includes a minimal FastAPI and worker bootstrap for upcoming product work.
+
+## Quality checks
+
+The baseline CI workflow runs on pushes to `main` and pull requests. It validates the current monorepo quality gate:
+
+- frontend dependency install, typecheck, and build
+- backend uv sync, Ruff linting, and pytest smoke tests
+
+Run the same checks locally with:
+
+```sh
+make ci
+```
 
 ## Local development services
 

--- a/backend/tests/test_api_health.py
+++ b/backend/tests/test_api_health.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+from optimark_athena.app import app
+
+
+def test_healthcheck_reports_backend_workspace() -> None:
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "app_name": "optimark",
+        "service_name": "athena",
+        "layer": "api",
+        "persistence_provider": "postgres",
+        "workspace_packages": ["metis", "mnemosyne", "clio"],
+    }

--- a/backend/tests/test_worker_bootstrap.py
+++ b/backend/tests/test_worker_bootstrap.py
@@ -1,0 +1,16 @@
+import json
+
+from optimark_hermes.__main__ import main
+
+
+def test_worker_bootstrap_prints_workspace_message(capsys) -> None:
+    main()
+
+    captured = capsys.readouterr()
+
+    assert json.loads(captured.out) == {
+        "status": "ok",
+        "worker_name": "hermes",
+        "persistence_provider": "postgres",
+        "workspace_packages": ["metis", "mnemosyne", "clio"],
+    }


### PR DESCRIPTION
## Summary

- Add CI workflow for frontend and backend quality gates
- Add backend smoke tests so pytest is a real baseline gate
- Add local make ci target and README docs

## Verification

- make ci
- make help
- git diff --check

Closes #29