### PR TITLE
fix(frontend): elevate runtime package upgrade

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,9 +22,11 @@ WORKDIR /app
 ENV HOST=0.0.0.0
 ENV PORT=4173
 
+USER root
 RUN ["/usr/bin/apt-get", "update"]
 RUN ["/usr/bin/apt-get", "install", "--yes", "--only-upgrade", "libssl3t64", "openssl", "openssl-provider-legacy"]
 RUN ["/usr/bin/apt-get", "clean"]
+USER 65532:65532
 
 COPY --chown=65532:65532 --from=build /app/frontend/apps/apollo/dist ./dist
 COPY --chown=65532:65532 frontend/apps/apollo/server.ts ./server.ts


### PR DESCRIPTION
## Summary
- run the frontend runtime package upgrade as root in the hardened Bun image
- drop back to the non-root runtime UID after the upgrade

## Testing
- make ci
- git diff --check

## Context
PR #39 merged the initial code scanning fixes, but the follow-up push-on-main build showed the apt-based package refresh needed a temporary user elevation inside the shell-less hardened image.
