### PR TITLE
feat(frontend): add shared design system foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ optimark/
 
 - Bun-managed frontend workspace
 - `apps/apollo`: routed React SPA for instructors, TAs, and students
-- `packages/calliope`: shared frontend theme and shell copy package
+- `packages/calliope`: shared frontend design-system package for tokens, shell primitives, and reusable surface patterns
 - Planned next frontend packages:
   `packages/iris` for notifications and messaging,
   `packages/hephaestus` for shared tooling/config,
   and `apps/museion` for a pattern-library workspace
-- Includes the initial routed SPA, shared shell, and mockup-inspired scaffold screens
+- Includes the initial routed SPA, mockup-aligned shell primitives, and reusable scaffold surfaces for future feature work
 
 ### `backend/`
 

--- a/docs/adr/0006-frontend-bun-workspace-package-topology.md
+++ b/docs/adr/0006-frontend-bun-workspace-package-topology.md
@@ -32,6 +32,14 @@ The current and planned package topology is:
 #### `packages/calliope`
 `calliope` is needed to hold presentation-layer primitives that should remain reusable across the frontend. This starts with brand and shell constants, but should grow into shared UI primitives, layout conventions, and design-language helpers. Pulling these out early prevents the main app from becoming the only place where visual consistency is defined.
 
+As of 2026-04-25, `calliope` is implemented as the shared frontend design-system package and includes:
+- brand and course-context configuration
+- design tokens for typography, color, spacing, radius, and shadow
+- shell primitives such as the sidebar, topbar, page header, and action bar
+- reusable surface patterns such as metric cards, status pills, form scaffolds, and empty states
+
+The initial primitive set is intentionally derived from the mockups under `docs/mockups/` so future frontend issues can extend a consistent visual system rather than reinterpreting the interface route by route.
+
 #### `packages/iris`
 `iris` is needed because notifications, toasts, inbox items, activity signaling, and cross-surface user messaging are product concerns that cut across many pages. Keeping them in a dedicated package avoids duplicating event-display patterns across feature areas and creates a clear home for delivery semantics that are broader than any single route.
 
@@ -54,6 +62,7 @@ The current and planned package topology is:
 
 ### Follow-on implications
 - New shared UI or shell primitives should default to `calliope` unless they are clearly app-local.
+- Apollo should use `calliope` as the default source for design tokens, shell composition, and reusable layout/surface patterns instead of recreating those concerns in app-local CSS.
 - Notification and inbox workflows should prefer `iris` once implemented instead of being recreated inside `apollo`.
 - Frontend build/config helpers should prefer `hephaestus` once implemented instead of accumulating in app-level scripts.
 - Component documentation and UI validation work should prefer `museion` once implemented instead of adding internal-only surfaces to the production app.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,13 +18,13 @@ This workspace contains the Bun frontend monorepo for Optimark.
 
 ## Workspace Layout
 - `apps/apollo`: main React SPA
-- `packages/calliope`: shared frontend theme and UI copy package
+- `packages/calliope`: shared frontend design-system package for tokens, shell primitives, and reusable surface patterns
 
 ## Package Roadmap
 - `apps/apollo`: implemented
   Primary web application for instructors, TAs, and students.
 - `packages/calliope`: implemented
-  Shared brand tokens, shell copy, and the first seam for reusable UI primitives.
+  Shared brand tokens, shell primitives, layout scaffolds, and reusable surface patterns derived from the design mockups in `docs/mockups/`.
 - `packages/iris`: planned
   Notifications, toasts, inbox-style messaging, and other user-facing system signals.
 - `packages/hephaestus`: planned
@@ -32,4 +32,4 @@ This workspace contains the Bun frontend monorepo for Optimark.
 - `apps/museion`: planned
   Internal pattern library or Storybook-style workspace for documenting components, flows, and visual decisions.
 
-The current implementation provides the initial app shell and mockup-inspired route scaffolding for future instructor and student flows. The dashboard and assignment editor screens are intentionally scaffold-grade, while the rest of the route tree is ready for issue-focused product work.
+The current implementation provides a mockup-aligned design system in `calliope` plus a routed Apollo showcase that exercises dashboard, editor, gradebook, and empty-state patterns for future instructor and student flows.

--- a/frontend/apps/apollo/src/main.tsx
+++ b/frontend/apps/apollo/src/main.tsx
@@ -12,6 +12,7 @@ import {
   redirect,
   Outlet,
   Link,
+  useRouterState,
 } from "@tanstack/react-router";
 import {
   Bell,
@@ -350,8 +351,10 @@ function AppSidebar() {
 }
 
 function AppTopbar() {
-  const path = router.state.location.pathname;
-  const activeTopTab = path === "/gradebook" ? "analytics" : "course-settings";
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const activeTopTab = pathname === "/gradebook" ? "analytics" : "course-settings";
 
   return (
     <Topbar

--- a/frontend/apps/apollo/src/main.tsx
+++ b/frontend/apps/apollo/src/main.tsx
@@ -16,8 +16,14 @@ import {
 import {
   Bell,
   BookOpen,
-  Clock3,
+  ChartColumn,
+  ChevronDown,
+  CircleAlert,
+  Code2,
+  Download,
   FileCode2,
+  Filter,
+  FolderOpen,
   Gauge,
   GraduationCap,
   History,
@@ -26,114 +32,189 @@ import {
   Search,
   Settings,
   Sparkles,
+  SquareTerminal,
+  Upload,
   Users,
 } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
-import { brand, shellTabs, shellUtilityLinks } from "@optimark/calliope";
+import {
+  AppFrame,
+  BottomActionBar,
+  BrandLockup,
+  EmptyState,
+  FormFieldScaffold,
+  MetricCard,
+  PageHeader,
+  PageShell,
+  SectionHeading,
+  SidebarNavItem,
+  SidebarShell,
+  StatusPill,
+  SurfacePanel,
+  Topbar,
+  TopbarTab,
+  brand,
+  sidebarUtilityLinks,
+  topTabs,
+} from "@optimark/calliope";
+import "@optimark/calliope/system.css";
 import "./styles.css";
 
 type AppContext = {
   queryClient: QueryClient;
 };
 
-type FoundationMetric = {
-  label: string;
-  value: string;
-  context: string;
-  tone?: "default" | "accent" | "alert";
-};
-
-type ScaffoldRoute = {
-  path: string;
-  summary: string;
-  status: "ready" | "planned" | "stub";
-};
-
-type FoundationPattern = {
-  title: string;
-  description: string;
-};
-
-type FoundationOverview = {
-  title: string;
-  subtitle: string;
-  metrics: FoundationMetric[];
-  routes: ScaffoldRoute[];
-  patterns: FoundationPattern[];
-};
-
 const queryClient = new QueryClient();
 
-const foundationOverview: FoundationOverview = {
-  title: `${brand.name} Shell`,
-  subtitle: "Router, query, package boundaries, and shared shell primitives are wired for future product tickets.",
-  metrics: [
-    { label: "Routes", value: "7", context: "Scaffolded", tone: "accent" },
-    { label: "Query", value: "1", context: "Provider" },
-    { label: "Packages", value: "2", context: "Apollo + Calliope" },
-    { label: "Status", value: "Ready", context: "Bootstrap", tone: "alert" },
-  ],
-  routes: [
-    {
-      path: "/dashboard",
-      summary: "Shell preview and shared foundation patterns.",
-      status: "ready",
-    },
-    {
-      path: "/assignments",
-      summary: "Reserved for issue #8 assignment management flows.",
-      status: "planned",
-    },
-    {
-      path: "/assignments/new",
-      summary: "Reserved route for the future assignment builder entrypoint.",
-      status: "stub",
-    },
-    {
-      path: "/submissions",
-      summary: "Reserved for student submission and processing work.",
-      status: "planned",
-    },
-    {
-      path: "/gradebook",
-      summary: "Reserved for instructor and student read-oriented grade views.",
-      status: "planned",
-    },
-    {
-      path: "/students",
-      summary: "Reserved for roster and per-student workflow surfaces.",
-      status: "planned",
-    },
-    {
-      path: "/settings",
-      summary: "Reserved for course configuration and policy controls.",
-      status: "planned",
-    },
-  ],
-  patterns: [
-    {
-      title: "App Shell",
-      description: "Persistent sidebar, sticky top bar, and centered workspace canvas are ready for authenticated flows.",
-    },
-    {
-      title: "Page Primitives",
-      description: "Page headers, actions, placeholder states, and surface panels are available for future screens.",
-    },
-    {
-      title: "State Styling",
-      description: "Status pills, loading states, and restrained surface treatments provide a consistent baseline.",
-    },
-    {
-      title: "Package Boundaries",
-      description: "Apollo owns the app runtime while Calliope owns shared brand and shell definitions.",
-    },
-  ],
-};
+const navItems = [
+  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { to: "/assignments", label: "Assignments", icon: BookOpen },
+  { to: "/submissions", label: "Submissions", icon: ListChecks },
+  { to: "/gradebook", label: "Gradebook", icon: ChartColumn },
+  { to: "/students", label: "Students", icon: Users },
+  { to: "/settings", label: "Settings", icon: Settings },
+] as const;
 
-const loadFoundationOverview = async (): Promise<FoundationOverview> => {
-  await new Promise((resolve) => setTimeout(resolve, 60));
-  return foundationOverview;
-};
+const assignmentRows = [
+  {
+    name: "Homework 4: Linked Lists",
+    type: "Practical",
+    status: { label: "Published", tone: "primary" as const },
+    due: "Oct 12, 23:59",
+    submissions: "42 / 45",
+  },
+  {
+    name: "Assignment 3: Binary Trees",
+    type: "Programming",
+    status: { label: "Reviewing", tone: "secondary" as const },
+    due: "Oct 05, 12:00",
+    submissions: "45 / 45",
+  },
+  {
+    name: "Midterm Quiz: Core Concepts",
+    type: "Exam",
+    status: { label: "Draft", tone: "default" as const },
+    due: "Oct 24, 09:00",
+    submissions: "0 / 45",
+  },
+  {
+    name: "Homework 5: Graph Theory",
+    type: "Practical",
+    status: { label: "Draft", tone: "default" as const },
+    due: "Nov 02, 23:59",
+    submissions: "0 / 45",
+  },
+] as const;
+
+const activityFeed = [
+  {
+    title: "Student A submitted Homework 4",
+    when: "12 minutes ago",
+    detail: "New programming artifact is ready for queueing.",
+    tone: "primary" as const,
+  },
+  {
+    title: "Autograde completed for Assignment 3",
+    when: "45 minutes ago",
+    detail: "82% average • 4 error flags surfaced for review.",
+    tone: "secondary" as const,
+  },
+  {
+    title: "Manual review started on Midterm Essays",
+    when: "2 hours ago",
+    detail: "TA review batch is currently in progress.",
+    tone: "default" as const,
+  },
+  {
+    title: "System: Plagiarism detected in Homework 4",
+    when: "3 hours ago",
+    detail: "One critical alert needs instructor verification.",
+    tone: "danger" as const,
+  },
+] as const;
+
+const starterFiles = [
+  {
+    name: "linked_list.py",
+    meta: "Python Source • 2.4 KB",
+    icon: <FileCode2 size={18} />,
+  },
+  {
+    name: "test_suite.py",
+    meta: "Python Test • 5.1 KB",
+    icon: <SquareTerminal size={18} />,
+  },
+] as const;
+
+const gradebookRows = [
+  {
+    initials: "AA",
+    student: "Alex Abramov",
+    email: "a.abramov@university.edu",
+    accent: "secondary" as const,
+    scores: [
+      { value: "95/100", status: "Released", tone: "primary" as const },
+      { value: "88/100", status: "Released", tone: "primary" as const },
+      { value: "--/100", status: "Pending", tone: "secondary" as const },
+      { value: "--/100", status: "Missing", tone: "default" as const },
+      { value: "142/150", status: "Released", tone: "primary" as const },
+    ],
+    overall: "91.4%",
+    overallTone: "primary" as const,
+  },
+  {
+    initials: "EL",
+    student: "Elena Laveau",
+    email: "e.laveau@university.edu",
+    accent: "secondary" as const,
+    scores: [
+      { value: "100/100", status: "Released", tone: "primary" as const },
+      { value: "94/100", status: "Released", tone: "primary" as const },
+      { value: "98/100", status: "Released", tone: "primary" as const },
+      { value: "92/100", status: "Released", tone: "primary" as const },
+      { value: "148/150", status: "Released", tone: "primary" as const },
+    ],
+    overall: "97.8%",
+    overallTone: "primary" as const,
+  },
+  {
+    initials: "JM",
+    student: "Jordan Miller",
+    email: "j.miller@university.edu",
+    accent: "danger" as const,
+    scores: [
+      { value: "64/100", status: "Released", tone: "primary" as const },
+      { value: "72/100", status: "Released", tone: "primary" as const },
+      { value: "--/100", status: "Pending", tone: "secondary" as const },
+      { value: "--/100", status: "Pending", tone: "secondary" as const },
+      { value: "110/150", status: "Released", tone: "primary" as const },
+    ],
+    overall: "68.2%",
+    overallTone: "danger" as const,
+  },
+  {
+    initials: "SW",
+    student: "Sarah Wu",
+    email: "s.wu@university.edu",
+    accent: "secondary" as const,
+    scores: [
+      { value: "92/100", status: "Released", tone: "primary" as const },
+      { value: "89/100", status: "Released", tone: "primary" as const },
+      { value: "91/100", status: "Released", tone: "primary" as const },
+      { value: "88/100", status: "Released", tone: "primary" as const },
+      { value: "138/150", status: "Released", tone: "primary" as const },
+    ],
+    overall: "90.5%",
+    overallTone: "primary" as const,
+  },
+] as const;
+
+const gradeDistribution = [
+  { label: "F", height: "18%", accent: false },
+  { label: "D", height: "42%", accent: false },
+  { label: "C", height: "78%", accent: true },
+  { label: "B", height: "60%", accent: false },
+  { label: "A", height: "14%", accent: false },
+] as const;
 
 const rootRoute = createRootRouteWithContext<AppContext>()({
   component: RootLayout,
@@ -150,19 +231,19 @@ const indexRoute = createRoute({
 const dashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/dashboard",
-  component: FoundationPreviewPage,
+  component: DashboardPage,
 });
 
 const assignmentsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/assignments",
-  component: AssignmentsOverviewPage,
+  component: AssignmentsPage,
 });
 
 const assignmentEditorRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/assignments/new",
-  component: AssignmentBuilderRoutePage,
+  component: AssignmentBuilderPage,
 });
 
 const submissionsRoute = createRoute({
@@ -215,315 +296,524 @@ declare module "@tanstack/react-router" {
 
 function RootLayout() {
   return (
-    <div className="app-frame">
-      <AppSidebar />
-      <div className="workspace">
-        <TopBar />
-        <div className="workspace-scroll">
-          <Outlet />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-type NavItemProps = {
-  to: string;
-  label: string;
-  icon: React.ComponentType<{ className?: string; size?: number }>;
-};
-
-function NavItem({ to, label, icon: Icon }: NavItemProps) {
-  return (
-    <Link
-      to={to}
-      className="sidebar-link"
-      activeProps={{ className: "sidebar-link sidebar-link-active" }}
+    <AppFrame
+      sidebar={<AppSidebar />}
+      topbar={<AppTopbar />}
     >
-      <Icon className="sidebar-link-icon" size={16} />
-      <span>{label}</span>
-    </Link>
+      <Outlet />
+    </AppFrame>
   );
 }
 
 function AppSidebar() {
   return (
-    <aside className="sidebar">
-      <div className="brand-lockup">
-        <div className="brand-mark">
-          <FileCode2 size={16} />
+    <SidebarShell
+      brand={
+        <BrandLockup
+          name={brand.name}
+          context={brand.courseLabel}
+          mark={<Code2 size={18} />}
+        />
+      }
+      navigation={navItems.map(({ to, label, icon: Icon }) => (
+        <Link key={to} to={to}>
+          {({ isActive }) => (
+            <SidebarNavItem
+              active={isActive}
+              icon={<Icon size={20} />}
+              label={label}
+            />
+          )}
+        </Link>
+      ))}
+      primaryAction={
+        <Link to="/assignments/new" className="app-primary-action">
+          New Assessment
+        </Link>
+      }
+      utilityLinks={sidebarUtilityLinks.map((item) => (
+        <div key={item.key} className="app-utility-link">
+          {item.label}
         </div>
-        <div>
-          <h1>{brand.name}</h1>
-          <p>{brand.courseLabel}</p>
-        </div>
-      </div>
-
-      <nav className="sidebar-nav">
-        <NavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} />
-        <NavItem to="/assignments" label="Assignments" icon={BookOpen} />
-        <NavItem to="/submissions" label="Submissions" icon={ListChecks} />
-        <NavItem to="/gradebook" label="Gradebook" icon={Gauge} />
-        <NavItem to="/students" label="Students" icon={Users} />
-        <NavItem to="/settings" label="Settings" icon={Settings} />
-      </nav>
-
-      <div className="sidebar-footer">
-        <button className="primary-shell-action">New Assessment</button>
-        <div className="sidebar-quiet-links">
-          {shellUtilityLinks.map((item) => (
-            <span key={item}>{item}</span>
-          ))}
-        </div>
-        <div className="profile-chip">
-          <div className="profile-avatar">AT</div>
+      ))}
+      profile={
+        <div className="app-profile-chip">
+          <div className="app-profile-avatar">AT</div>
           <div>
             <strong>{brand.instructorName}</strong>
             <p>{brand.instructorRole}</p>
           </div>
         </div>
-      </div>
-    </aside>
+      }
+    />
   );
 }
 
-function TopBar() {
-  return (
-    <header className="topbar">
-      <nav className="topbar-links">
-        {shellTabs.map((tab, index) => (
-          <span key={tab} className={index === 0 ? "topbar-active" : undefined}>
-            {tab}
-          </span>
-        ))}
-      </nav>
+function AppTopbar() {
+  const path = router.state.location.pathname;
+  const activeTopTab = path === "/gradebook" ? "analytics" : "course-settings";
 
-      <div className="topbar-tools">
-        <label className="search-shell">
-          <Search size={14} />
+  return (
+    <Topbar
+      tabs={topTabs.map((tab) => (
+        <TopbarTab key={tab.key} active={tab.key === activeTopTab}>
+          {tab.label}
+        </TopbarTab>
+      ))}
+      search={
+        <label className="app-search">
+          <Search size={16} />
           <input placeholder="Search assessments..." />
         </label>
-        <button className="icon-button" aria-label="Notifications">
-          <Bell size={16} />
-        </button>
-        <button className="icon-button" aria-label="History">
-          <History size={16} />
-        </button>
-        <div className="profile-avatar profile-avatar-small">AT</div>
-      </div>
-    </header>
+      }
+      tools={
+        <div className="app-topbar-tools">
+          <button className="app-icon-button" type="button" aria-label="Notifications">
+            <Bell size={18} />
+          </button>
+          <button className="app-icon-button" type="button" aria-label="History">
+            <History size={18} />
+          </button>
+          <div className="app-topbar-avatar">AT</div>
+        </div>
+      }
+    />
   );
 }
 
-function PageHeader(props: {
-  eyebrow?: string;
-  title: string;
-  subtitle?: string;
-  actions?: React.ReactNode;
-}) {
+function DashboardPage() {
   return (
-    <div className="page-header">
-      <div>
-        {props.eyebrow ? <p className="eyebrow">{props.eyebrow}</p> : null}
-        <h2>{props.title}</h2>
-        {props.subtitle ? <p className="page-subtitle">{props.subtitle}</p> : null}
-      </div>
-      {props.actions ? <div className="page-actions">{props.actions}</div> : null}
-    </div>
-  );
-}
-
-function FoundationPreviewPage() {
-  const { data } = useQuery({
-    queryKey: ["foundation-overview"],
-    queryFn: loadFoundationOverview,
-  });
-
-  if (!data) {
-    return <PageSkeleton title="Loading shell preview..." />;
-  }
-
-  return (
-    <section className="page-shell">
+    <PageShell>
       <PageHeader
-        title={data.title}
-        subtitle={data.subtitle}
+        title={brand.courseLabel}
+        subtitle={`${brand.courseTerm} • ${brand.viewLabel}`}
         actions={
           <>
-            <button className="secondary-shell-action">Secondary Action</button>
-            <button className="primary-shell-action">Primary Action</button>
+            <button className="app-secondary-action" type="button">
+              <LayoutDashboard size={16} />
+              Open Gradebook
+            </button>
+            <button className="app-primary-action" type="button">
+              <Upload size={16} />
+              Publish All
+            </button>
           </>
         }
       />
 
-      <div className="stats-grid">
-        {data.metrics.map((stat) => (
-          <article key={stat.label} className="stat-panel">
-            <span className={`stat-label stat-label-${stat.tone ?? "default"}`}>
-              {stat.label}
-            </span>
-            <div className="stat-row">
-              <strong>{stat.value}</strong>
-              <span>{stat.context}</span>
-            </div>
-          </article>
-        ))}
+      <div className="app-metric-grid">
+        <MetricCard label="Drafts" value="4" context="Items" />
+        <MetricCard label="Published" value="12" context="Live" tone="primary" />
+        <MetricCard label="Pending Review" value="8" context="Grading" tone="danger" />
+        <MetricCard label="Completed" value="45" context="Students" />
       </div>
 
-      <div className="content-grid">
-        <section className="surface-panel panel-large">
-          <div className="panel-heading">
-            <h3>Route Map</h3>
-            <span className="inline-action">Shared Scaffold</span>
-          </div>
+      <div className="app-dashboard-grid">
+        <SurfacePanel className="app-table-panel">
+          <SectionHeading
+            icon={<BookOpen size={16} />}
+            title="Active Coursework"
+            actions={
+              <button className="app-inline-control" type="button">
+                Filter
+                <ChevronDown size={14} />
+              </button>
+            }
+          />
 
-          <div className="table-shell">
-            <table>
-              <thead>
-                <tr>
-                  <th>Path</th>
-                  <th>Purpose</th>
-                  <th className="align-right">Status</th>
+          <table className="app-dense-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Status</th>
+                <th>Due Date</th>
+                <th className="align-right">Submissions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {assignmentRows.map((row) => (
+                <tr key={row.name}>
+                  <td className="app-table-strong">{row.name}</td>
+                  <td>{row.type}</td>
+                  <td>
+                    <StatusPill tone={row.status.tone}>{row.status.label}</StatusPill>
+                  </td>
+                  <td>{row.due}</td>
+                  <td className="align-right app-table-strong">{row.submissions}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {data.routes.map((route) => (
-                  <tr key={route.path}>
-                    <td className="cell-strong">{route.path}</td>
-                    <td>{route.summary}</td>
-                    <td className="align-right">
-                      <span className={`status-pill status-${route.status}`}>
-                        {route.status}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
+              ))}
+            </tbody>
+          </table>
+        </SurfacePanel>
 
-        <aside className="surface-panel panel-activity">
-          <div className="panel-heading">
-            <h3>Foundation Patterns</h3>
-            <Sparkles size={14} />
-          </div>
-
-          <div className="activity-list">
-            {data.patterns.map((item) => (
-              <article key={item.title} className="activity-item">
-                <div className="activity-mark">
-                  <Sparkles size={14} />
+        <SurfacePanel className="app-feed-panel">
+          <SectionHeading
+            icon={<Sparkles size={16} />}
+            title="Operational Feed"
+          />
+          <div className="app-feed-list">
+            {activityFeed.map((item) => (
+              <article key={item.title} className="app-feed-item">
+                <div className={`app-feed-icon app-feed-icon-${item.tone}`}>
+                  {item.tone === "danger" ? <CircleAlert size={16} /> : <FileCode2 size={16} />}
                 </div>
                 <div>
                   <strong>{item.title}</strong>
-                  <p>{item.description}</p>
+                  <p>{item.when}</p>
+                  <span>{item.detail}</span>
                 </div>
               </article>
             ))}
           </div>
-        </aside>
+        </SurfacePanel>
       </div>
-    </section>
+
+      <BottomActionBar
+        leading={
+          <>
+            <span className="app-smallcaps">Quick Actions</span>
+            <button className="app-icon-button" type="button" aria-label="Search quick actions">
+              <Search size={16} />
+            </button>
+          </>
+        }
+        actions={
+          <>
+            <button className="app-inline-action" type="button">Regrade</button>
+            <button className="app-inline-action" type="button">Download CSV</button>
+          </>
+        }
+      />
+    </PageShell>
   );
 }
 
-function AssignmentBuilderRoutePage() {
+function AssignmentsPage() {
   return (
-    <PlaceholderPage
-      title="Assignment Builder Route"
-      subtitle="This route is reserved for the future assignment editor flow in issue #8."
-    />
+    <PageShell>
+      <PageHeader
+        eyebrow="Foundation Surface"
+        title="Assignment workflows"
+        subtitle="The design system now supports calm inspector layouts, file rails, and editorial form treatment for future instructor flows."
+        actions={
+          <Link to="/assignments/new" className="app-primary-action">
+            Open Editor
+          </Link>
+        }
+      />
+      <EmptyState
+        icon={<FolderOpen size={18} />}
+        title="Reusable assignment patterns are ready"
+        description="Issue #8 can plug actual assignment data and actions into this shared shell without restyling the workspace."
+      />
+    </PageShell>
   );
 }
 
-function AssignmentsOverviewPage() {
+function AssignmentBuilderPage() {
   return (
-    <PlaceholderPage
-      title="Assignments"
-      subtitle="Use this route group for future assignment lists, creation flows, and publishing controls."
-      actionLabel="Open Reserved Builder Route"
-      actionTo="/assignments/new"
-    />
+    <PageShell>
+      <PageHeader
+        eyebrow="Assignment Editor"
+        title="Homework 4: Linked Lists"
+      />
+
+      <div className="app-editor-grid">
+        <div className="app-editor-main">
+          <SectionHeading
+            icon={<FileCode2 size={16} />}
+            title="Description"
+            actions={
+              <div className="app-inline-group">
+                <button className="app-inline-action app-inline-action-active" type="button">
+                  Write
+                </button>
+                <button className="app-inline-action" type="button">
+                  Preview
+                </button>
+              </div>
+            }
+          />
+
+          <SurfacePanel muted className="app-editor-block">
+            <pre>{`## Instructions
+Implement a singly linked list with the following methods:
+- append(value)
+- prepend(value)
+- delete(value)
+- find(value)
+
+### Constraints
+- Time Complexity: O(n) for searching
+- Space Complexity: O(1) for deletions
+
+Ensure all edge cases are handled (empty list, single node list).`}</pre>
+          </SurfacePanel>
+
+          <SectionHeading
+            icon={<FolderOpen size={16} />}
+            title="Starter Files"
+          />
+          <div className="app-file-stack">
+            {starterFiles.map((file) => (
+              <SurfacePanel key={file.name} muted className="app-file-row">
+                <div className="app-file-main">
+                  <div className="app-file-icon">{file.icon}</div>
+                  <div>
+                    <strong>{file.name}</strong>
+                    <p>{file.meta}</p>
+                  </div>
+                </div>
+              </SurfacePanel>
+            ))}
+            <div className="app-upload-zone">
+              <Upload size={18} />
+              Upload Additional Files
+            </div>
+          </div>
+        </div>
+
+        <SurfacePanel muted className="app-editor-inspector">
+          <SectionHeading title="Metadata" />
+          <div className="app-inspector-grid">
+            <FormFieldScaffold label="Due Date">
+              <div className="app-field-value">Oct 15, 2026</div>
+            </FormFieldScaffold>
+            <FormFieldScaffold label="Points">
+              <div className="app-field-value">100</div>
+            </FormFieldScaffold>
+            <FormFieldScaffold label="Language">
+              <div className="app-field-value">Python 3.10</div>
+            </FormFieldScaffold>
+            <FormFieldScaffold label="Submission Limit" support="3 attempts">
+              <div className="app-slider-track">
+                <span />
+              </div>
+            </FormFieldScaffold>
+          </div>
+          <div className="app-inspector-meta">
+            <div className="app-meta-row">
+              <span>Visibility</span>
+              <StatusPill>Hidden</StatusPill>
+            </div>
+            <div className="app-meta-row">
+              <span>Category</span>
+              <StatusPill tone="primary">Coding</StatusPill>
+            </div>
+          </div>
+          <button className="app-verify-card" type="button">
+            <Sparkles size={22} />
+            Verify Environment
+          </button>
+        </SurfacePanel>
+      </div>
+
+      <BottomActionBar
+        leading={
+          <div className="app-status-cluster">
+            <span className="app-smallcaps">Current Status</span>
+            <strong>Draft Saving...</strong>
+          </div>
+        }
+        actions={
+          <>
+            <button className="app-inline-action" type="button">Save Draft</button>
+            <button className="app-primary-action" type="button">Publish</button>
+          </>
+        }
+      />
+    </PageShell>
   );
 }
 
 function SubmissionsPage() {
   return (
-    <PlaceholderPage
-      title="Submissions"
-      subtitle="This route is ready for queue views, processing states, and review-focused assignment drilldowns."
-    />
+    <PageShell>
+      <PageHeader
+        title="Submission queue"
+        subtitle="Shared list, status, and action-bar primitives are ready for student and staff queue flows."
+      />
+      <EmptyState
+        icon={<ListChecks size={18} />}
+        title="Submission workflows will plug in here"
+        description="The design system now supports high-density queue views and calm operational empty states."
+      />
+    </PageShell>
   );
 }
 
 function GradebookPage() {
   return (
-    <PlaceholderPage
-      title="Gradebook"
-      subtitle="This shell is ready for dense table layouts, grade-release workflows, and student-by-assignment summaries."
-    />
+    <PageShell>
+      <div className="app-gradebook-shell">
+        <div className="app-gradebook-main">
+          <SurfacePanel muted className="app-overview-card">
+            <h3>Academic Overview</h3>
+            <p>{brand.courseLabel} • {brand.courseTerm}</p>
+            <div className="app-overview-metrics">
+              <div>
+                <span className="app-smallcaps">Average Grade</span>
+                <strong>84.2</strong>
+              </div>
+              <div>
+                <span className="app-smallcaps">Completion Rate</span>
+                <strong>92%</strong>
+              </div>
+              <div>
+                <span className="app-smallcaps">Next Deadline</span>
+                <strong>Oct 12</strong>
+              </div>
+            </div>
+          </SurfacePanel>
+
+          <div className="app-filter-row">
+            <FormFieldScaffold label="Filter by Student">
+              <div className="app-filter-pill">
+                All Students
+                <ChevronDown size={16} />
+              </div>
+            </FormFieldScaffold>
+            <FormFieldScaffold label="Assignment Status">
+              <div className="app-filter-pill">
+                All Statuses
+                <Filter size={16} />
+              </div>
+            </FormFieldScaffold>
+            <div className="app-filter-actions">
+              <button className="app-secondary-action" type="button">
+                <Download size={16} />
+                Export CSV
+              </button>
+              <button className="app-secondary-action" type="button">
+                <Settings size={16} />
+                View Settings
+              </button>
+            </div>
+          </div>
+
+          <SurfacePanel className="app-gradebook-table-panel">
+            <table className="app-gradebook-table">
+              <thead>
+                <tr>
+                  <th>Student Name</th>
+                  <th>HW 1</th>
+                  <th>HW 2</th>
+                  <th>HW 3</th>
+                  <th>HW 4</th>
+                  <th>Midterm</th>
+                  <th className="align-right">Overall</th>
+                </tr>
+              </thead>
+              <tbody>
+                {gradebookRows.map((row) => (
+                  <tr key={row.email}>
+                    <td>
+                      <div className="app-student-cell">
+                        <div className={`app-student-avatar app-student-avatar-${row.accent}`}>
+                          {row.initials}
+                        </div>
+                        <div>
+                          <strong>{row.student}</strong>
+                          <p>{row.email}</p>
+                        </div>
+                      </div>
+                    </td>
+                    {row.scores.map((score, index) => (
+                      <td key={`${row.email}-${index}`}>
+                        <strong className="app-grade-cell">{score.value}</strong>
+                        <StatusPill tone={score.tone}>{score.status}</StatusPill>
+                      </td>
+                    ))}
+                    <td className={`align-right app-overall-${row.overallTone}`}>
+                      {row.overall}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </SurfacePanel>
+        </div>
+
+        <SurfacePanel className="app-chart-panel">
+          <SectionHeading title="Grading Distribution" />
+          <div className="app-chart-bars">
+            {gradeDistribution.map((bar) => (
+              <div key={bar.label} className="app-chart-column">
+                <div
+                  className={`app-chart-bar ${bar.accent ? "app-chart-bar-accent" : ""}`}
+                  style={{ height: bar.height }}
+                />
+                <span>{bar.label}</span>
+              </div>
+            ))}
+          </div>
+        </SurfacePanel>
+      </div>
+
+      <BottomActionBar
+        leading={
+          <div className="app-status-cluster">
+            <span className="app-smallcaps">3 students selected</span>
+            <strong>Batch actions ready</strong>
+          </div>
+        }
+        actions={
+          <>
+            <button className="app-inline-action" type="button">Message</button>
+            <button className="app-inline-action" type="button">Batch Edit</button>
+            <button className="app-primary-action" type="button">Release Selected</button>
+          </>
+        }
+      />
+    </PageShell>
   );
 }
 
 function StudentsPage() {
   return (
-    <PlaceholderPage
-      title="Students"
-      subtitle="Future roster, enrollment, and per-student activity surfaces can plug into the shared shell here."
-    />
+    <PageShell>
+      <PageHeader
+        title="Roster surfaces"
+        subtitle="The shared shell, list, and metadata treatments are ready for future student-centric workflows."
+      />
+      <EmptyState
+        icon={<GraduationCap size={18} />}
+        title="Roster primitives are now part of the system"
+        description="Issue-specific student views can reuse the gradebook table rhythm, metadata labels, and sidebar shell without forking styles."
+      />
+    </PageShell>
   );
 }
 
 function SettingsPage() {
   return (
-    <PlaceholderPage
-      title="Settings"
-      subtitle="Use this area for course configuration, grading policies, integrations, and audit-oriented controls."
-    />
-  );
-}
-
-function PlaceholderPage(props: {
-  title: string;
-  subtitle: string;
-  actionLabel?: string;
-  actionTo?: string;
-}) {
-  return (
-    <section className="page-shell">
+    <PageShell>
       <PageHeader
-        title={props.title}
-        subtitle={props.subtitle}
-        actions={
-          props.actionLabel && props.actionTo ? (
-            <Link to={props.actionTo} className="primary-shell-action">
-              {props.actionLabel}
-            </Link>
-          ) : undefined
-        }
+        title="Course settings"
+        subtitle="Configuration pages can reuse the same inspector and form-field scaffolds from the assignment editor."
       />
-
-      <div className="placeholder-surface">
-        <GraduationCap size={18} />
-        <p>
-          Shared app shell, routing, and styling are wired. This screen is a lightweight
-          placeholder for issue-focused product work to land next.
-        </p>
+      <div className="app-settings-grid">
+        <SurfacePanel muted className="app-settings-panel">
+          <SectionHeading title="Grading policy" icon={<Gauge size={16} />} />
+          <FormFieldScaffold label="Release cadence">
+            <div className="app-field-value">Manual review gate</div>
+          </FormFieldScaffold>
+          <FormFieldScaffold label="Visibility default">
+            <div className="app-field-value">Hidden until publish</div>
+          </FormFieldScaffold>
+        </SurfacePanel>
+        <SurfacePanel muted className="app-settings-panel">
+          <SectionHeading title="Operational defaults" icon={<Sparkles size={16} />} />
+          <FormFieldScaffold label="Autograde retries">
+            <div className="app-field-value">2 retries</div>
+          </FormFieldScaffold>
+          <FormFieldScaffold label="Audit retention">
+            <div className="app-field-value">Full term archive</div>
+          </FormFieldScaffold>
+        </SurfacePanel>
       </div>
-    </section>
-  );
-}
-
-function PageSkeleton(props: { title: string }) {
-  return (
-    <section className="page-shell">
-      <PageHeader title={props.title} subtitle="Preparing workspace..." />
-      <div className="placeholder-surface">
-        <Clock3 size={18} />
-        <p>Loading mock data and shared workspace context.</p>
-      </div>
-    </section>
+    </PageShell>
   );
 }
 

--- a/frontend/apps/apollo/src/styles.css
+++ b/frontend/apps/apollo/src/styles.css
@@ -1,623 +1,590 @@
-:root {
-  --bg: #f6f5f2;
-  --surface: #ffffff;
-  --surface-soft: #eef2f0;
-  --surface-line: #d9e0de;
-  --surface-deep: #dbe4e2;
-  --text: #2b3434;
-  --muted: #667171;
-  --primary: #255f6f;
-  --primary-strong: #16424d;
-  --primary-soft: #d3e6ea;
-  --warning: #a44646;
-  --warning-soft: #f3d9d7;
-  --shadow: 0 18px 42px rgba(43, 52, 52, 0.06);
-  --radius-lg: 20px;
-  --radius-md: 14px;
-  --sidebar-width: 15.75rem;
-  font-family: "Inter", sans-serif;
-  color: var(--text);
-  background: var(--bg);
-}
-
-* {
-  box-sizing: border-box;
-}
-
-html,
-body,
-#root {
-  min-height: 100%;
-  margin: 0;
-}
-
-body {
-  background:
-    radial-gradient(circle at top right, rgba(37, 95, 111, 0.08), transparent 28rem),
-    linear-gradient(180deg, #faf8f5 0%, var(--bg) 100%);
-  color: var(--text);
-}
-
-button,
-input,
-textarea,
-select {
-  font: inherit;
-}
-
-button {
-  border: 0;
-  background: none;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.app-frame {
-  display: flex;
-  min-height: 100vh;
-}
-
-.sidebar {
-  width: var(--sidebar-width);
-  background: linear-gradient(180deg, #eaf0ef 0%, #e6eded 100%);
-  border-right: 1px solid rgba(37, 95, 111, 0.08);
-  padding: 1.6rem 1rem 1rem;
-  position: fixed;
-  inset: 0 auto 0 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.brand-lockup {
-  display: flex;
-  align-items: center;
-  gap: 0.9rem;
-  padding: 0 0.85rem;
-}
-
-.brand-mark {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.65rem;
-  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-strong) 100%);
-  color: white;
-  display: grid;
-  place-items: center;
-  box-shadow: 0 10px 22px rgba(37, 95, 111, 0.22);
-}
-
-.brand-lockup h1 {
-  margin: 0;
-  font: 800 1.45rem/1 "Manrope", sans-serif;
-  color: var(--primary-strong);
-}
-
-.brand-lockup p {
-  margin: 0.25rem 0 0;
-  font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--muted);
-}
-
-.sidebar-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-}
-
-.sidebar-link {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.8rem 0.9rem;
-  border-radius: 0.9rem;
-  color: #6b7878;
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  transition: background 140ms ease, color 140ms ease, transform 140ms ease;
-}
-
-.sidebar-link:hover {
-  background: rgba(255, 255, 255, 0.7);
-  color: var(--primary-strong);
-  transform: translateX(1px);
-}
-
-.sidebar-link-active {
-  background: rgba(255, 255, 255, 0.82);
-  color: var(--primary-strong);
-  box-shadow: inset -3px 0 0 var(--primary);
-}
-
-.sidebar-link-icon {
-  opacity: 0.86;
-}
-
-.sidebar-footer {
-  margin-top: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.primary-shell-action,
-.secondary-shell-action,
-.inline-action {
+.app-primary-action,
+.app-secondary-action,
+.app-inline-action,
+.app-inline-control {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.45rem;
-  border-radius: 0.9rem;
-  font-size: 0.75rem;
+  gap: 0.55rem;
+  border-radius: 0.75rem;
+  font-size: 0.82rem;
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   transition: transform 140ms ease, box-shadow 140ms ease, background 140ms ease;
 }
 
-.primary-shell-action {
-  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-strong) 100%);
-  color: white;
-  padding: 0.85rem 1rem;
-  box-shadow: 0 14px 28px rgba(37, 95, 111, 0.2);
+.app-primary-action {
+  padding: 0.95rem 1.2rem;
+  color: #eefaff;
+  background: linear-gradient(135deg, var(--calliope-primary), var(--calliope-primary-dim));
+  box-shadow: 0 14px 28px rgba(33, 89, 105, 0.2);
 }
 
-.primary-shell-action:hover,
-.secondary-shell-action:hover,
-.inline-action:hover {
+.app-secondary-action {
+  padding: 0.95rem 1.2rem;
+  color: var(--calliope-text);
+  background: rgba(227, 233, 232, 0.92);
+}
+
+.app-inline-action,
+.app-inline-control {
+  color: var(--calliope-primary-dim);
+}
+
+.app-inline-action-active {
+  color: var(--calliope-text);
+}
+
+.app-primary-action:hover,
+.app-secondary-action:hover,
+.app-inline-action:hover,
+.app-inline-control:hover,
+.app-icon-button:hover,
+.app-upload-zone:hover {
   transform: translateY(-1px);
 }
 
-.secondary-shell-action {
-  background: rgba(232, 238, 237, 0.92);
-  color: var(--text);
-  padding: 0.85rem 1rem;
-}
-
-.inline-action {
-  color: var(--primary);
-  font-size: 0.68rem;
-}
-
-.sidebar-quiet-links {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  color: var(--muted);
-  font-size: 0.74rem;
+.app-utility-link,
+.app-smallcaps {
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  padding: 0 0.45rem;
+  color: #5f718e;
 }
 
-.profile-chip {
+.app-utility-link {
+  padding: 0.75rem 1rem;
+}
+
+.app-profile-chip {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.8rem 0.45rem 0;
-  border-top: 1px solid rgba(43, 52, 52, 0.08);
+  gap: 0.85rem;
+  padding: 1rem 1rem 0;
+  border-top: 1px solid rgba(171, 180, 179, 0.18);
 }
 
-.profile-avatar {
-  width: 2.3rem;
-  height: 2.3rem;
-  border-radius: 50%;
+.app-profile-avatar,
+.app-topbar-avatar {
   display: grid;
   place-items: center;
-  font-size: 0.74rem;
+  color: #eefaff;
+  background: linear-gradient(135deg, var(--calliope-primary), var(--calliope-primary-dim));
+}
+
+.app-profile-avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
   font-weight: 800;
-  color: white;
-  background: linear-gradient(135deg, var(--primary) 0%, #173f49 100%);
 }
 
-.profile-avatar-small {
-  width: 1.95rem;
-  height: 1.95rem;
-  font-size: 0.68rem;
-}
-
-.profile-chip strong,
-.profile-chip p {
+.app-profile-chip strong {
   display: block;
+  font-size: 0.9rem;
 }
 
-.profile-chip strong {
-  font-size: 0.8rem;
+.app-profile-chip p {
+  margin: 0.2rem 0 0;
+  color: var(--calliope-text-muted);
+  font-size: 0.77rem;
 }
 
-.profile-chip p {
-  margin: 0.1rem 0 0;
-  font-size: 0.68rem;
-  color: var(--muted);
-}
-
-.workspace {
-  flex: 1;
-  margin-left: var(--sidebar-width);
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
-.topbar {
-  height: 4.25rem;
-  padding: 0 2.2rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid rgba(43, 52, 52, 0.07);
-  background: rgba(250, 248, 245, 0.8);
-  backdrop-filter: blur(14px);
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
-.topbar-links {
-  display: flex;
-  gap: 1.6rem;
-  color: var(--muted);
-  font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.topbar-active {
-  color: var(--primary-strong);
-  position: relative;
-}
-
-.topbar-active::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: -1.55rem;
-  height: 2px;
-  background: var(--primary);
-}
-
-.topbar-tools {
+.app-search {
+  width: min(20rem, 100%);
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65rem;
+  padding: 0.95rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(227, 233, 232, 0.92);
+  color: #7b8795;
 }
 
-.search-shell {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  min-width: 18rem;
-  padding: 0.72rem 0.95rem;
-  border-radius: 0.9rem;
-  background: rgba(233, 238, 237, 0.78);
-  color: var(--muted);
-}
-
-.search-shell input {
+.app-search input {
   width: 100%;
   background: transparent;
   border: 0;
   outline: 0;
-  color: var(--text);
+  color: var(--calliope-text);
 }
 
-.icon-button {
-  width: 2.1rem;
-  height: 2.1rem;
+.app-topbar-tools {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.app-icon-button {
+  width: 2.4rem;
+  height: 2.4rem;
   display: grid;
   place-items: center;
   border-radius: 999px;
-  color: var(--muted);
+  color: #61728f;
 }
 
-.icon-button:hover {
-  background: rgba(233, 238, 237, 0.92);
-  color: var(--primary-strong);
-}
-
-.workspace-scroll {
-  flex: 1;
-  padding: 2rem 2.2rem 2.7rem;
-}
-
-.page-shell {
-  max-width: 84rem;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1.8rem;
-}
-
-.page-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  gap: 1rem;
-}
-
-.eyebrow {
-  margin: 0 0 0.35rem;
-  font-size: 0.72rem;
+.app-topbar-avatar {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
   font-weight: 800;
-  color: var(--primary);
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
 }
 
-.page-header h2 {
-  margin: 0;
-  font: 800 3rem/0.98 "Manrope", sans-serif;
-  letter-spacing: -0.03em;
-}
-
-.page-subtitle {
-  margin: 0.45rem 0 0;
-  color: var(--muted);
-  font-size: 0.84rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.page-actions {
-  display: flex;
-  gap: 0.7rem;
-  flex-wrap: wrap;
-}
-
-.stats-grid {
+.app-metric-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1rem;
 }
 
-.stat-panel,
-.surface-panel,
-.placeholder-surface {
-  background: rgba(255, 255, 255, 0.82);
-  border: 1px solid rgba(43, 52, 52, 0.06);
-  box-shadow: var(--shadow);
-}
-
-.stat-panel {
-  border-radius: var(--radius-lg);
-  padding: 1.35rem 1.4rem;
-}
-
-.stat-label {
-  display: inline-block;
-  font-size: 0.66rem;
-  font-weight: 800;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.stat-label-accent {
-  color: var(--primary);
-}
-
-.stat-label-alert {
-  color: var(--warning);
-}
-
-.stat-row {
-  margin-top: 1rem;
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-}
-
-.stat-row strong {
-  font: 800 2.7rem/1 "Manrope", sans-serif;
-}
-
-.stat-row span {
-  color: var(--muted);
-  font-size: 0.84rem;
-}
-
-.content-grid {
+.app-dashboard-grid {
   display: grid;
-  grid-template-columns: minmax(0, 2.2fr) minmax(20rem, 1fr);
-  gap: 1.25rem;
+  grid-template-columns: minmax(0, 2fr) minmax(20rem, 1fr);
+  gap: 1.4rem;
 }
 
-.surface-panel {
-  border-radius: var(--radius-lg);
-  padding: 1.2rem;
+.app-table-panel,
+.app-feed-panel,
+.app-overview-card,
+.app-chart-panel,
+.app-gradebook-table-panel,
+.app-editor-block,
+.app-editor-inspector,
+.app-settings-panel {
+  padding: 1.5rem;
 }
 
-.panel-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin-bottom: 0.95rem;
-}
-
-.panel-heading h3 {
-  margin: 0;
-  font-size: 0.96rem;
-  font-weight: 800;
-}
-
-.table-shell {
-  overflow: auto;
-}
-
-table {
+.app-dense-table,
+.app-gradebook-table {
   width: 100%;
   border-collapse: collapse;
 }
 
-th,
-td {
-  padding: 1rem 0.95rem;
-  border-bottom: 1px solid rgba(43, 52, 52, 0.07);
+.app-dense-table th,
+.app-dense-table td,
+.app-gradebook-table th,
+.app-gradebook-table td {
+  padding: 1.15rem 1rem;
+  border-bottom: 1px solid rgba(171, 180, 179, 0.16);
   text-align: left;
-  font-size: 0.88rem;
+  vertical-align: top;
 }
 
-th {
-  color: var(--muted);
-  font-size: 0.68rem;
+.app-dense-table th,
+.app-gradebook-table th {
+  color: #95a0a8;
+  font-size: 0.74rem;
   font-weight: 800;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
-}
-
-.cell-strong {
-  font-weight: 700;
 }
 
 .align-right {
-  text-align: right;
+  text-align: right !important;
 }
 
-.status-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.28rem 0.55rem;
-  border-radius: 999px;
-  font-size: 0.66rem;
+.app-table-strong,
+.app-grade-cell,
+.app-student-cell strong {
   font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
-.status-ready {
-  background: var(--primary-soft);
-  color: var(--primary-strong);
-}
-
-.status-planned {
-  background: #dde4f4;
-  color: #51627c;
-}
-
-.status-stub {
-  background: var(--surface-soft);
-  color: var(--muted);
-}
-
-.activity-list {
+.app-feed-list {
   display: flex;
   flex-direction: column;
-  gap: 0.95rem;
+  gap: 1rem;
 }
 
-.activity-item {
+.app-feed-item {
   display: flex;
-  gap: 0.9rem;
-  padding-bottom: 0.95rem;
-  border-bottom: 1px solid rgba(43, 52, 52, 0.06);
+  gap: 0.95rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(171, 180, 179, 0.16);
 }
 
-.activity-item:last-child {
+.app-feed-item:last-child {
   border-bottom: 0;
   padding-bottom: 0;
 }
 
-.activity-mark {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.7rem;
+.app-feed-icon {
+  width: 2.4rem;
+  height: 2.4rem;
   display: grid;
   place-items: center;
-  color: var(--primary-strong);
-  background: var(--primary-soft);
+  border-radius: 0.7rem;
   flex: 0 0 auto;
 }
 
-.activity-alert {
-  color: var(--warning);
-  background: var(--warning-soft);
+.app-feed-icon-default {
+  background: rgba(220, 228, 227, 0.95);
+  color: #738188;
 }
 
-.activity-item strong {
+.app-feed-icon-primary {
+  background: rgba(182, 235, 254, 0.76);
+  color: var(--calliope-primary-dim);
+}
+
+.app-feed-icon-secondary {
+  background: rgba(213, 227, 252, 0.85);
+  color: #51627c;
+}
+
+.app-feed-icon-danger {
+  background: rgba(254, 137, 131, 0.25);
+  color: var(--calliope-error);
+}
+
+.app-feed-item strong {
   display: block;
-  font-size: 0.84rem;
+  font-size: 0.98rem;
 }
 
-.activity-item p {
-  margin: 0.35rem 0 0;
-  color: var(--muted);
-  font-size: 0.78rem;
-  line-height: 1.5;
+.app-feed-item p,
+.app-feed-item span,
+.app-file-main p,
+.app-student-cell p,
+.app-overview-card p {
+  color: var(--calliope-text-muted);
 }
 
-.placeholder-surface {
-  border-radius: var(--radius-lg);
-  padding: 1.4rem;
+.app-feed-item p,
+.app-feed-item span,
+.app-file-main p,
+.app-student-cell p {
+  margin: 0.28rem 0 0;
+}
+
+.app-editor-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.9fr) minmax(18rem, 0.8fr);
+  gap: 2rem;
+}
+
+.app-editor-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-editor-block pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font: 400 1rem/1.85 "IBM Plex Mono", "SFMono-Regular", monospace;
+  color: #5d6668;
+}
+
+.app-inline-group {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-file-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.app-file-row {
+  display: flex;
+  align-items: center;
+}
+
+.app-file-main {
+  display: flex;
+  align-items: center;
+  gap: 0.95rem;
+}
+
+.app-file-main strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.app-file-icon {
+  color: var(--calliope-primary);
+}
+
+.app-upload-zone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  min-height: 5rem;
+  border-radius: 1rem;
+  border: 2px dashed rgba(171, 180, 179, 0.35);
+  color: #7d8ea7;
+  font-size: 0.88rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.app-editor-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  position: sticky;
+  top: 6.5rem;
+  height: fit-content;
+}
+
+.app-inspector-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.app-field-value,
+.app-filter-pill {
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  padding: 0.8rem 1rem;
+  border-radius: 0.8rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(171, 180, 179, 0.16);
+}
+
+.app-slider-track {
+  width: 100%;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: rgba(171, 180, 179, 0.22);
+  position: relative;
+}
+
+.app-slider-track span {
+  position: absolute;
+  inset: 50% auto auto 34%;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 999px;
+  transform: translate(-50%, -50%);
+  background: var(--calliope-primary);
+}
+
+.app-inspector-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(171, 180, 179, 0.18);
+}
+
+.app-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.app-verify-card {
+  min-height: 10.5rem;
+  border-radius: 1rem;
+  color: #eefaff;
+  background:
+    radial-gradient(circle at center, rgba(255, 255, 255, 0.09), transparent 35%),
+    linear-gradient(135deg, #173f49, var(--calliope-primary-dim));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.9rem;
+  font-size: 0.95rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.app-gradebook-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1.9fr) minmax(18rem, 0.9fr);
+  gap: 1.4rem;
+}
+
+.app-gradebook-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.app-overview-card h3 {
+  margin: 0;
+  font: 800 1.9rem/1 Manrope, sans-serif;
+}
+
+.app-overview-card p {
+  margin: 0.45rem 0 0;
+  font-size: 1rem;
+}
+
+.app-overview-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.4rem;
+  margin-top: 2rem;
+}
+
+.app-overview-metrics strong {
+  display: block;
+  margin-top: 0.55rem;
+  font: 800 3rem/1 Manrope, sans-serif;
+}
+
+.app-filter-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: end;
+}
+
+.app-filter-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.app-gradebook-table-panel {
+  overflow: hidden;
+}
+
+.app-gradebook-table th {
+  background: rgba(241, 244, 243, 0.86);
+}
+
+.app-student-cell {
   display: flex;
   align-items: center;
   gap: 0.9rem;
-  color: var(--muted);
 }
 
-@media (max-width: 1100px) {
-  .stats-grid,
-  .content-grid {
+.app-student-avatar {
+  width: 2.55rem;
+  height: 2.55rem;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+}
+
+.app-student-avatar-secondary {
+  background: rgba(213, 227, 252, 0.95);
+  color: #4f5d72;
+}
+
+.app-student-avatar-danger {
+  background: rgba(254, 137, 131, 0.28);
+  color: var(--calliope-error);
+}
+
+.app-overall-primary {
+  color: var(--calliope-primary);
+  font-weight: 800;
+}
+
+.app-overall-danger {
+  color: var(--calliope-error);
+  font-weight: 800;
+}
+
+.app-chart-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.app-chart-bars {
+  height: 15rem;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
+  align-items: end;
+}
+
+.app-chart-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-chart-bar {
+  width: 100%;
+  border-radius: 0.6rem 0.6rem 0 0;
+  background: rgba(136, 168, 181, 0.88);
+}
+
+.app-chart-bar-accent {
+  background: linear-gradient(180deg, #3d7788, var(--calliope-primary));
+}
+
+.app-chart-column span {
+  color: var(--calliope-text-muted);
+  font-size: 0.85rem;
+}
+
+.app-settings-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.app-settings-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.app-status-cluster {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.app-status-cluster strong {
+  font-size: 1rem;
+}
+
+@media (max-width: 1200px) {
+  .app-metric-grid,
+  .app-overview-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .app-dashboard-grid,
+  .app-editor-grid,
+  .app-gradebook-shell,
+  .app-settings-grid,
+  .app-filter-row {
     grid-template-columns: 1fr;
   }
+
+  .app-editor-inspector {
+    position: static;
+  }
+
+  .app-filter-actions {
+    justify-content: flex-start;
+  }
 }
 
-@media (max-width: 900px) {
-  .sidebar {
-    position: static;
-    width: 100%;
-    border-right: 0;
-    border-bottom: 1px solid rgba(43, 52, 52, 0.08);
+@media (max-width: 780px) {
+  .app-metric-grid,
+  .app-overview-metrics,
+  .app-inspector-grid {
+    grid-template-columns: 1fr;
   }
 
-  .app-frame {
-    flex-direction: column;
-  }
-
-  .workspace {
-    margin-left: 0;
-  }
-
-  .topbar {
-    padding: 0 1rem;
-    flex-wrap: wrap;
-    gap: 1rem;
-    height: auto;
-    min-height: 4.25rem;
-  }
-
-  .topbar-links {
-    order: 2;
-    width: 100%;
-    overflow: auto;
-    padding-bottom: 0.5rem;
-  }
-
-  .page-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .page-header h2 {
-    font-size: 2.35rem;
-  }
-
-  .workspace-scroll {
-    padding: 1.3rem 1rem 2rem;
-  }
-
-  .search-shell {
-    min-width: 0;
+  .app-search {
     width: 100%;
   }
 }

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -28,7 +28,12 @@
       "name": "@optimark/calliope",
       "version": "0.1.0",
       "devDependencies": {
+        "@types/react": "^19.2.2",
+        "react": "^19.2.0",
         "typescript": "^5.9.3",
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
       },
     },
   },

--- a/frontend/packages/calliope/package.json
+++ b/frontend/packages/calliope/package.json
@@ -3,21 +3,27 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "files": [
-    "dist"
-  ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && cp src/system.css dist/system.css",
     "check": "tsc --noEmit -p tsconfig.json"
   },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./system.css": "./dist/system.css"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.2",
+    "react": "^19.2.0",
+    "typescript": "^5.9.3"
   },
   "types": "./dist/index.d.ts",
-  "devDependencies": {
-    "typescript": "^5.9.3"
-  }
+  "files": [
+    "dist"
+  ]
 }

--- a/frontend/packages/calliope/src/config.ts
+++ b/frontend/packages/calliope/src/config.ts
@@ -1,0 +1,56 @@
+/** Shared Calliope configuration and design-token values. */
+
+export const brand = {
+  name: "Optimark",
+  courseLabel: "CS101: Data Structures",
+  courseTerm: "Fall 2026 Term",
+  viewLabel: "Instructor View",
+  instructorName: "Dr. Aris Thorne",
+  instructorRole: "Lead Instructor",
+} as const;
+
+export const topTabs = [
+  { key: "course-settings", label: "Course Settings" },
+  { key: "analytics", label: "Analytics" },
+  { key: "audit-log", label: "Audit Log" },
+] as const;
+
+export const sidebarUtilityLinks = [
+  { key: "help", label: "Help" },
+  { key: "archive", label: "Archive" },
+] as const;
+
+export const designTokens = {
+  color: {
+    background: "#f9f9f8",
+    surface: "#ffffff",
+    surfaceLow: "#f1f4f3",
+    surfaceContainer: "#eaefee",
+    surfaceHigh: "#e3e9e8",
+    surfaceHighest: "#dce4e3",
+    surfaceDim: "#d2dcdb",
+    outlineVariant: "#abb4b3",
+    text: "#2c3433",
+    textMuted: "#586160",
+    primary: "#306576",
+    primaryDim: "#215969",
+    primaryContainer: "#b6ebfe",
+    secondaryContainer: "#d5e3fc",
+    error: "#9f403d",
+    errorContainer: "#fe8983",
+  },
+  radius: {
+    sm: "0.25rem",
+    md: "0.5rem",
+    lg: "0.75rem",
+    xl: "1.25rem",
+  },
+  shadow: {
+    ambient: "0 12px 40px rgba(44, 52, 51, 0.06)",
+    subtle: "0 10px 28px rgba(44, 52, 51, 0.04)",
+  },
+  type: {
+    displayFamily: "Manrope, sans-serif",
+    bodyFamily: "Inter, sans-serif",
+  },
+} as const;

--- a/frontend/packages/calliope/src/index.ts
+++ b/frontend/packages/calliope/src/index.ts
@@ -1,19 +1,4 @@
-export const brand = {
-  name: "Optimark",
-  courseLabel: "CS101: Data Structures",
-  courseTerm: "Fall 2026 Term",
-  viewLabel: "Instructor View",
-  instructorName: "Dr. Aris Thorne",
-  instructorRole: "Lead Instructor",
-} as const;
+/** Shared frontend design-system exports for Optimark. */
 
-export const shellTabs = [
-  "Course Settings",
-  "Analytics",
-  "Audit Log",
-] as const;
-
-export const shellUtilityLinks = [
-  "Help",
-  "Archive",
-] as const;
+export * from "./config";
+export * from "./primitives";

--- a/frontend/packages/calliope/src/primitives.tsx
+++ b/frontend/packages/calliope/src/primitives.tsx
@@ -1,0 +1,315 @@
+/** Reusable shell and UI primitives for the Optimark frontend workspace. */
+
+import type { HTMLAttributes, ReactNode } from "react";
+
+export type ShellBrandProps = {
+  name: string;
+  context: string;
+  mark: ReactNode;
+};
+
+export function BrandLockup({ name, context, mark }: ShellBrandProps) {
+  return (
+    <div className="calliope-brand-lockup">
+      <div className="calliope-brand-mark">{mark}</div>
+      <div>
+        <h1>{name}</h1>
+        <p>{context}</p>
+      </div>
+    </div>
+  );
+}
+
+type SidebarShellProps = {
+  brand: ReactNode;
+  navigation: ReactNode;
+  primaryAction?: ReactNode;
+  utilityLinks?: ReactNode;
+  profile?: ReactNode;
+};
+
+export function SidebarShell({
+  brand,
+  navigation,
+  primaryAction,
+  utilityLinks,
+  profile,
+}: SidebarShellProps) {
+  return (
+    <aside className="calliope-sidebar">
+      {brand}
+      <nav className="calliope-sidebar-nav">{navigation}</nav>
+      <div className="calliope-sidebar-footer">
+        {primaryAction}
+        {utilityLinks ? (
+          <div className="calliope-sidebar-utility">{utilityLinks}</div>
+        ) : null}
+        {profile}
+      </div>
+    </aside>
+  );
+}
+
+type SidebarNavItemProps = {
+  active?: boolean;
+  icon: ReactNode;
+  label: string;
+  trailing?: ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
+
+export function SidebarNavItem({
+  active = false,
+  icon,
+  label,
+  trailing,
+  className = "",
+  ...props
+}: SidebarNavItemProps) {
+  return (
+    <div
+      className={`calliope-sidebar-link ${active ? "calliope-sidebar-link-active" : ""} ${className}`.trim()}
+      {...props}
+    >
+      <span className="calliope-sidebar-link-icon">{icon}</span>
+      <span>{label}</span>
+      {trailing ? <span>{trailing}</span> : null}
+    </div>
+  );
+}
+
+type TopbarProps = {
+  tabs?: ReactNode;
+  search?: ReactNode;
+  tools?: ReactNode;
+  actions?: ReactNode;
+};
+
+export function Topbar({ tabs, search, tools, actions }: TopbarProps) {
+  return (
+    <header className="calliope-topbar">
+      <div className="calliope-topbar-tabs">{tabs}</div>
+      <div className="calliope-topbar-right">
+        {search}
+        {tools}
+        {actions}
+      </div>
+    </header>
+  );
+}
+
+type TopbarTabProps = {
+  active?: boolean;
+  children: ReactNode;
+} & HTMLAttributes<HTMLButtonElement>;
+
+export function TopbarTab({
+  active = false,
+  children,
+  className = "",
+  ...props
+}: TopbarTabProps) {
+  return (
+    <button
+      className={`calliope-topbar-tab ${active ? "calliope-topbar-tab-active" : ""} ${className}`.trim()}
+      type="button"
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+type AppFrameProps = {
+  sidebar: ReactNode;
+  topbar: ReactNode;
+  children: ReactNode;
+};
+
+export function AppFrame({ sidebar, topbar, children }: AppFrameProps) {
+  return (
+    <div className="calliope-app-frame">
+      {sidebar}
+      <div className="calliope-workspace">
+        {topbar}
+        <div className="calliope-workspace-scroll">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+type PageShellProps = {
+  children: ReactNode;
+};
+
+export function PageShell({ children }: PageShellProps) {
+  return <section className="calliope-page-shell">{children}</section>;
+}
+
+type PageHeaderProps = {
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+};
+
+export function PageHeader({
+  eyebrow,
+  title,
+  subtitle,
+  actions,
+}: PageHeaderProps) {
+  return (
+    <div className="calliope-page-header">
+      <div>
+        {eyebrow ? <p className="calliope-eyebrow">{eyebrow}</p> : null}
+        <h2>{title}</h2>
+        {subtitle ? <p className="calliope-page-subtitle">{subtitle}</p> : null}
+      </div>
+      {actions ? <div className="calliope-page-actions">{actions}</div> : null}
+    </div>
+  );
+}
+
+type SurfacePanelProps = {
+  children: ReactNode;
+  muted?: boolean;
+  className?: string;
+};
+
+export function SurfacePanel({
+  children,
+  muted = false,
+  className = "",
+}: SurfacePanelProps) {
+  return (
+    <div
+      className={`calliope-surface-panel ${muted ? "calliope-surface-panel-muted" : ""} ${className}`.trim()}
+    >
+      {children}
+    </div>
+  );
+}
+
+type SectionHeadingProps = {
+  icon?: ReactNode;
+  title: string;
+  actions?: ReactNode;
+};
+
+export function SectionHeading({
+  icon,
+  title,
+  actions,
+}: SectionHeadingProps) {
+  return (
+    <div className="calliope-section-heading">
+      <h3>
+        {icon ? <span className="calliope-section-heading-icon">{icon}</span> : null}
+        {title}
+      </h3>
+      {actions}
+    </div>
+  );
+}
+
+type MetricCardProps = {
+  label: string;
+  value: string;
+  context?: string;
+  tone?: "default" | "primary" | "danger";
+};
+
+export function MetricCard({
+  label,
+  value,
+  context,
+  tone = "default",
+}: MetricCardProps) {
+  return (
+    <article className="calliope-metric-card">
+      <span className={`calliope-metric-label calliope-tone-${tone}`}>{label}</span>
+      <div className="calliope-metric-row">
+        <strong>{value}</strong>
+        {context ? <span>{context}</span> : null}
+      </div>
+    </article>
+  );
+}
+
+type StatusPillProps = {
+  tone?: "default" | "primary" | "secondary" | "danger";
+  children: ReactNode;
+};
+
+export function StatusPill({
+  tone = "default",
+  children,
+}: StatusPillProps) {
+  return (
+    <span className={`calliope-status-pill calliope-status-${tone}`}>
+      {children}
+    </span>
+  );
+}
+
+type EmptyStateProps = {
+  icon?: ReactNode;
+  title: string;
+  description: string;
+  action?: ReactNode;
+};
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+}: EmptyStateProps) {
+  return (
+    <SurfacePanel className="calliope-empty-state">
+      {icon ? <div className="calliope-empty-icon">{icon}</div> : null}
+      <div>
+        <strong>{title}</strong>
+        <p>{description}</p>
+      </div>
+      {action}
+    </SurfacePanel>
+  );
+}
+
+type FormFieldProps = {
+  label: string;
+  support?: string;
+  children: ReactNode;
+};
+
+export function FormFieldScaffold({
+  label,
+  support,
+  children,
+}: FormFieldProps) {
+  return (
+    <label className="calliope-form-field">
+      <span className="calliope-form-label">{label}</span>
+      {children}
+      {support ? <span className="calliope-form-support">{support}</span> : null}
+    </label>
+  );
+}
+
+type BottomActionBarProps = {
+  leading?: ReactNode;
+  actions: ReactNode;
+};
+
+export function BottomActionBar({
+  leading,
+  actions,
+}: BottomActionBarProps) {
+  return (
+    <div className="calliope-bottom-action-bar">
+      {leading ? <div className="calliope-bottom-leading">{leading}</div> : null}
+      <div className="calliope-bottom-actions">{actions}</div>
+    </div>
+  );
+}

--- a/frontend/packages/calliope/src/system.css
+++ b/frontend/packages/calliope/src/system.css
@@ -70,6 +70,7 @@ a {
   width: var(--calliope-sidebar-width);
   position: fixed;
   inset: 0 auto 0 0;
+  z-index: 30;
   display: flex;
   flex-direction: column;
   gap: 1.6rem;
@@ -418,11 +419,12 @@ a {
   position: fixed;
   left: calc(50% + var(--calliope-sidebar-width) / 2);
   bottom: 1.8rem;
+  z-index: 25;
   transform: translateX(-50%);
   display: flex;
   align-items: center;
   gap: 1rem;
-  min-width: min(50rem, calc(100vw - var(--calliope-sidebar-width) - 4rem));
+  width: min(50rem, calc(100vw - var(--calliope-sidebar-width) - 2rem));
   padding: 1rem 1.25rem;
   border-radius: 1.35rem;
   background: rgba(255, 255, 255, 0.85);
@@ -457,9 +459,7 @@ a {
   }
 
   .calliope-bottom-action-bar {
-    min-width: auto;
-    width: calc(100vw - 2rem);
-    left: 50%;
+    width: calc(100vw - var(--calliope-sidebar-width) - 2rem);
   }
 }
 
@@ -495,5 +495,10 @@ a {
 
   .calliope-workspace-scroll {
     padding: 1.3rem 1rem 7rem;
+  }
+
+  .calliope-bottom-action-bar {
+    left: 50%;
+    width: calc(100vw - 2rem);
   }
 }

--- a/frontend/packages/calliope/src/system.css
+++ b/frontend/packages/calliope/src/system.css
@@ -1,0 +1,499 @@
+:root {
+  --calliope-background: #f9f9f8;
+  --calliope-surface: #ffffff;
+  --calliope-surface-low: #f1f4f3;
+  --calliope-surface-container: #eaefee;
+  --calliope-surface-high: #e3e9e8;
+  --calliope-surface-highest: #dce4e3;
+  --calliope-surface-dim: #d2dcdb;
+  --calliope-outline-variant: rgba(171, 180, 179, 0.38);
+  --calliope-text: #2c3433;
+  --calliope-text-muted: #586160;
+  --calliope-primary: #306576;
+  --calliope-primary-dim: #215969;
+  --calliope-primary-container: #b6ebfe;
+  --calliope-secondary-container: #d5e3fc;
+  --calliope-error: #9f403d;
+  --calliope-error-container: #fe8983;
+  --calliope-shadow: 0 12px 40px rgba(44, 52, 51, 0.06);
+  --calliope-shadow-soft: 0 10px 28px rgba(44, 52, 51, 0.04);
+  --calliope-radius-sm: 0.25rem;
+  --calliope-radius-md: 0.5rem;
+  --calliope-radius-lg: 0.75rem;
+  --calliope-radius-xl: 1.25rem;
+  --calliope-sidebar-width: 19rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  background:
+    radial-gradient(circle at top right, rgba(48, 101, 118, 0.08), transparent 28rem),
+    linear-gradient(180deg, #fbfaf8 0%, var(--calliope-background) 100%);
+  color: var(--calliope-text);
+  font-family: Inter, sans-serif;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.calliope-app-frame {
+  display: flex;
+  min-height: 100vh;
+}
+
+.calliope-sidebar {
+  width: var(--calliope-sidebar-width);
+  position: fixed;
+  inset: 0 auto 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  padding: 1.25rem 1rem 1rem;
+  background: linear-gradient(180deg, #eef2f1 0%, #e8efee 100%);
+  border-right: 1px solid rgba(48, 101, 118, 0.07);
+}
+
+.calliope-brand-lockup {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.25rem 0.85rem 0;
+}
+
+.calliope-brand-mark {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.45rem;
+  display: grid;
+  place-items: center;
+  color: #eefaff;
+  background: linear-gradient(135deg, var(--calliope-primary), var(--calliope-primary-dim));
+  box-shadow: 0 10px 24px rgba(33, 89, 105, 0.18);
+}
+
+.calliope-brand-lockup h1 {
+  margin: 0;
+  font: 800 2.15rem/0.96 Manrope, sans-serif;
+  letter-spacing: -0.05em;
+  color: var(--calliope-primary-dim);
+}
+
+.calliope-brand-lockup p {
+  margin: 0.45rem 0 0;
+  font-size: 0.84rem;
+  color: #5e7593;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.calliope-sidebar-nav,
+.calliope-sidebar-footer {
+  display: flex;
+  flex-direction: column;
+}
+
+.calliope-sidebar-nav {
+  gap: 0.18rem;
+  padding-top: 1rem;
+}
+
+.calliope-sidebar-footer {
+  margin-top: auto;
+  gap: 1rem;
+}
+
+.calliope-sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 1rem;
+  border-radius: var(--calliope-radius-lg);
+  color: #5f718e;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: color 140ms ease, background 140ms ease, transform 140ms ease;
+}
+
+.calliope-sidebar-link:hover {
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--calliope-primary-dim);
+  transform: translateX(1px);
+}
+
+.calliope-sidebar-link-active {
+  color: var(--calliope-primary-dim);
+  background: rgba(255, 255, 255, 0.5);
+  box-shadow: inset -4px 0 0 var(--calliope-primary);
+}
+
+.calliope-sidebar-link-icon {
+  display: inline-flex;
+  color: inherit;
+}
+
+.calliope-sidebar-utility {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.calliope-workspace {
+  flex: 1;
+  margin-left: var(--calliope-sidebar-width);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.calliope-topbar {
+  height: 5rem;
+  padding: 0 2.4rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(249, 249, 248, 0.82);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(171, 180, 179, 0.18);
+}
+
+.calliope-topbar-tabs,
+.calliope-topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+}
+
+.calliope-topbar-tab {
+  padding: 1.5rem 0.05rem 1.35rem;
+  color: var(--calliope-text-muted);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: color 140ms ease;
+}
+
+.calliope-topbar-tab:hover {
+  color: var(--calliope-primary-dim);
+}
+
+.calliope-topbar-tab-active {
+  color: var(--calliope-primary-dim);
+  box-shadow: inset 0 -2px 0 var(--calliope-primary);
+}
+
+.calliope-workspace-scroll {
+  flex: 1;
+  padding: 2.3rem 2.4rem 7rem;
+}
+
+.calliope-page-shell {
+  max-width: 78rem;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.9rem;
+}
+
+.calliope-page-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.calliope-page-header h2 {
+  margin: 0;
+  font: 800 4rem/0.96 Manrope, sans-serif;
+  letter-spacing: -0.06em;
+}
+
+.calliope-page-subtitle,
+.calliope-eyebrow,
+.calliope-form-label,
+.calliope-metric-label,
+.calliope-section-heading h3,
+.calliope-status-pill {
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.calliope-eyebrow,
+.calliope-page-subtitle {
+  margin: 0;
+  color: var(--calliope-text-muted);
+}
+
+.calliope-eyebrow {
+  font-size: 0.74rem;
+  font-weight: 800;
+  color: var(--calliope-primary);
+  margin-bottom: 0.55rem;
+}
+
+.calliope-page-subtitle {
+  margin-top: 0.6rem;
+  font-size: 0.86rem;
+}
+
+.calliope-page-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.calliope-surface-panel {
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: var(--calliope-radius-xl);
+  box-shadow: var(--calliope-shadow-soft);
+  border: 1px solid rgba(171, 180, 179, 0.12);
+}
+
+.calliope-surface-panel-muted {
+  background: rgba(241, 244, 243, 0.8);
+}
+
+.calliope-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.calliope-section-heading h3 {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.82rem;
+  font-weight: 800;
+  color: var(--calliope-text-muted);
+}
+
+.calliope-section-heading-icon {
+  display: inline-flex;
+  color: var(--calliope-primary);
+}
+
+.calliope-metric-card {
+  background: rgba(255, 255, 255, 0.92);
+  padding: 1.7rem 1.8rem;
+  border-radius: var(--calliope-radius-xl);
+  box-shadow: var(--calliope-shadow-soft);
+}
+
+.calliope-metric-label {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 800;
+  color: var(--calliope-text-muted);
+}
+
+.calliope-tone-primary {
+  color: var(--calliope-primary);
+}
+
+.calliope-tone-danger {
+  color: var(--calliope-error);
+}
+
+.calliope-metric-row {
+  margin-top: 1.1rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.calliope-metric-row strong {
+  font: 800 3.25rem/1 Manrope, sans-serif;
+}
+
+.calliope-metric-row span {
+  color: var(--calliope-text-muted);
+  font-size: 1rem;
+}
+
+.calliope-status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.32rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.69rem;
+  font-weight: 800;
+  color: var(--calliope-text-muted);
+  background: rgba(220, 228, 227, 0.95);
+}
+
+.calliope-status-primary {
+  color: var(--calliope-primary-dim);
+  background: rgba(182, 235, 254, 0.92);
+}
+
+.calliope-status-secondary {
+  color: #4f5d72;
+  background: rgba(213, 227, 252, 0.95);
+}
+
+.calliope-status-danger {
+  color: var(--calliope-error);
+  background: rgba(254, 137, 131, 0.24);
+}
+
+.calliope-empty-state {
+  padding: 1.4rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.calliope-empty-state strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.calliope-empty-state p {
+  margin: 0.35rem 0 0;
+  color: var(--calliope-text-muted);
+}
+
+.calliope-empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: rgba(182, 235, 254, 0.72);
+  color: var(--calliope-primary-dim);
+}
+
+.calliope-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.calliope-form-label {
+  font-size: 0.72rem;
+  font-weight: 800;
+  color: #607492;
+}
+
+.calliope-form-support {
+  font-size: 0.77rem;
+  color: var(--calliope-text-muted);
+}
+
+.calliope-bottom-action-bar {
+  position: fixed;
+  left: calc(50% + var(--calliope-sidebar-width) / 2);
+  bottom: 1.8rem;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  min-width: min(50rem, calc(100vw - var(--calliope-sidebar-width) - 4rem));
+  padding: 1rem 1.25rem;
+  border-radius: 1.35rem;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--calliope-shadow);
+  border: 1px solid rgba(171, 180, 179, 0.16);
+}
+
+.calliope-bottom-leading {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding-right: 1rem;
+  border-right: 1px solid rgba(171, 180, 179, 0.22);
+}
+
+.calliope-bottom-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+@media (max-width: 1100px) {
+  .calliope-page-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .calliope-page-header h2 {
+    font-size: 3rem;
+  }
+
+  .calliope-bottom-action-bar {
+    min-width: auto;
+    width: calc(100vw - 2rem);
+    left: 50%;
+  }
+}
+
+@media (max-width: 900px) {
+  .calliope-app-frame {
+    flex-direction: column;
+  }
+
+  .calliope-sidebar {
+    position: static;
+    width: 100%;
+    border-right: 0;
+    border-bottom: 1px solid rgba(171, 180, 179, 0.2);
+  }
+
+  .calliope-workspace {
+    margin-left: 0;
+  }
+
+  .calliope-topbar {
+    padding: 0 1rem;
+    min-height: 5rem;
+    height: auto;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .calliope-topbar-tabs {
+    order: 2;
+    width: 100%;
+    overflow: auto;
+  }
+
+  .calliope-workspace-scroll {
+    padding: 1.3rem 1rem 7rem;
+  }
+}

--- a/frontend/packages/calliope/tsconfig.json
+++ b/frontend/packages/calliope/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary
- build a reusable Calliope frontend design-system package with shared tokens, shell primitives, and surface patterns
- refactor Apollo into a mockup-aligned showcase for dashboard, editor, gradebook, and empty-state foundations
- update frontend docs and ADR-0006 to reflect Calliope as the shared design-system package

## Verification
- bun run build (frontend/packages/calliope)
- bun run check (frontend/apps/apollo)
- bun run build (frontend)
- make ci
- git diff --check