### PR TITLE
refactor(frontend): split Apollo composition and fix Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,7 @@ RUN ["bun", "install", "--frozen-lockfile"]
 
 WORKDIR /app/frontend/packages/calliope
 RUN ["bun", "x", "tsc", "-p", "tsconfig.json"]
+RUN ["cp", "src/system.css", "dist/system.css"]
 
 WORKDIR /app/frontend/apps/apollo
 RUN ["bun", "x", "tsc", "--noEmit"]


### PR DESCRIPTION
## Summary
- split Apollo into route, feature, shell, and API modules
- move auth vs protected composition into pathless TanStack Router layout routes
- fix the frontend Docker build by generating Calliope's exported CSS artifact with hardened-image-compatible exec-form steps

## Notes
- This branch is stacked on top of the current frontend auth/design-system work, so the PR includes that frontend stack relative to main.

## Verification
- bun run check (frontend/apps/apollo)
- bun run build (frontend)
- make ci
- make frontend-docker-build
- git diff --check