### PR TITLE
feat(app): add instructor assignment management

### DIFF
--- a/backend/apps/api/src/optimark_athena/app.py
+++ b/backend/apps/api/src/optimark_athena/app.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI
 
 from optimark_athena.auth_routes import router as auth_router
+from optimark_athena.management_routes import router as management_router
 from optimark_clio.health import HealthResponse
 from optimark_metis.runtime import build_service_descriptor
 from optimark_mnemosyne.runtime import default_persistence_descriptor
@@ -14,6 +15,7 @@ app = FastAPI(
     version="0.1.0",
 )
 app.include_router(auth_router)
+app.include_router(management_router)
 
 
 @app.get("/health", response_model=HealthResponse, tags=["system"])

--- a/backend/apps/api/src/optimark_athena/dependencies.py
+++ b/backend/apps/api/src/optimark_athena/dependencies.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from optimark_athena.config import AuthSettings, load_auth_settings
 from optimark_metis import (
     AcademicService,
+    AssessmentService,
     AuthService,
     AuthenticationRequiredError,
     AuthorizationService,
@@ -22,6 +23,7 @@ from optimark_metis import (
 from optimark_metis.academic import User
 from optimark_metis.auth import AuthenticatedSession
 from optimark_mnemosyne import (
+    SqlAlchemyAssessmentRepository,
     SqlAlchemyAcademicRepository,
     SqlAlchemyAuthRepository,
     create_session_factory,
@@ -115,6 +117,25 @@ def get_auth_service(
         auth_repository=SqlAlchemyAuthRepository(db_session),
         password_hasher=password_hasher,
         session_ttl=auth_settings.session_ttl,
+    )
+
+
+def get_assessment_service(
+    db_session: Annotated[Session, Depends(get_db_session)],
+    academic_service: Annotated[AcademicService, Depends(get_academic_service)],
+) -> AssessmentService:
+    """Build the assessment service for the current request.
+
+    Args:
+        db_session: Request-scoped SQLAlchemy session.
+        academic_service: Academic service used for course and user lookups.
+
+    Returns:
+        AssessmentService: Assessment service backed by SQLAlchemy repositories.
+    """
+    return AssessmentService(
+        repository=SqlAlchemyAssessmentRepository(db_session),
+        academic_service=academic_service,
     )
 
 

--- a/backend/apps/api/src/optimark_athena/management_routes.py
+++ b/backend/apps/api/src/optimark_athena/management_routes.py
@@ -1,0 +1,273 @@
+"""Instructor-facing course and assignment management API routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from optimark_athena.dependencies import (
+    get_academic_service,
+    get_assessment_service,
+    require_authenticated_user,
+    require_course_capability,
+)
+from optimark_clio import (
+    AssignmentDetail,
+    AssignmentSummary,
+    AuthErrorResponse,
+    CourseSummary,
+    CreateCourseAssignmentInput,
+    UpdateAssignmentInput,
+)
+from optimark_metis import (
+    AcademicService,
+    Assignment,
+    AssessmentService,
+    CourseCapability,
+    EntityNotFoundError,
+    InvalidAssessmentDataError,
+)
+from optimark_metis.academic import CourseRole, User
+
+
+router = APIRouter(prefix="/api/v1", tags=["management"])
+
+
+@router.get(
+    "/courses/managed",
+    response_model=list[CourseSummary],
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": AuthErrorResponse},
+    },
+)
+def list_managed_courses(
+    current_user: Annotated[User, Depends(require_authenticated_user)],
+    academic_service: Annotated[AcademicService, Depends(get_academic_service)],
+) -> list[CourseSummary]:
+    """List courses the authenticated instructor can manage.
+
+    Args:
+        current_user: Authenticated platform user.
+        academic_service: Academic service used to resolve course memberships.
+
+    Returns:
+        list[CourseSummary]: Managed course summaries for the instructor.
+    """
+    courses = academic_service.list_courses_for_user(
+        current_user.id,
+        role_filter=CourseRole.INSTRUCTOR,
+    )
+    return [CourseSummary.from_domain(course) for course in courses]
+
+
+@router.get(
+    "/courses/{course_id}/assignments",
+    response_model=list[AssignmentSummary],
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": AuthErrorResponse},
+        status.HTTP_403_FORBIDDEN: {"model": AuthErrorResponse},
+        status.HTTP_404_NOT_FOUND: {"model": AuthErrorResponse},
+    },
+)
+def list_course_assignments(
+    course_id: UUID,
+    _: Annotated[
+        object,
+        Depends(require_course_capability(CourseCapability.MANAGE_COURSE)),
+    ],
+    assessment_service: Annotated[AssessmentService, Depends(get_assessment_service)],
+) -> list[AssignmentSummary]:
+    """List assignments for a managed course.
+
+    Args:
+        course_id: Course identifier from the route path.
+        _: Authenticated capability-gated session context.
+        assessment_service: Assessment service used to load assignments.
+
+    Returns:
+        list[AssignmentSummary]: Assignment summaries for the course.
+    """
+    assignments = assessment_service.list_course_assignments(course_id)
+    return [AssignmentSummary.from_domain(assignment) for assignment in assignments]
+
+
+@router.post(
+    "/courses/{course_id}/assignments",
+    response_model=AssignmentDetail,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {"model": AuthErrorResponse},
+        status.HTTP_401_UNAUTHORIZED: {"model": AuthErrorResponse},
+        status.HTTP_403_FORBIDDEN: {"model": AuthErrorResponse},
+        status.HTTP_404_NOT_FOUND: {"model": AuthErrorResponse},
+    },
+)
+def create_course_assignment(
+    course_id: UUID,
+    payload: CreateCourseAssignmentInput,
+    _: Annotated[
+        object,
+        Depends(require_course_capability(CourseCapability.MANAGE_COURSE)),
+    ],
+    assessment_service: Annotated[AssessmentService, Depends(get_assessment_service)],
+) -> AssignmentDetail:
+    """Create a new assignment within a managed course.
+
+    Args:
+        course_id: Course identifier from the route path.
+        payload: Assignment creation payload.
+        _: Authenticated capability-gated session context.
+        assessment_service: Assessment service used to persist the assignment.
+
+    Returns:
+        AssignmentDetail: Persisted assignment payload.
+
+    Raises:
+        HTTPException: If the payload is invalid.
+    """
+    try:
+        assignment = assessment_service.create_assignment(
+            course_id=course_id,
+            title=payload.title,
+            description=payload.description,
+            assignment_type=payload.assignment_type,
+            publish_state=payload.publish_state,
+        )
+    except InvalidAssessmentDataError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return AssignmentDetail.from_domain(assignment)
+
+
+@router.get(
+    "/courses/{course_id}/assignments/{assignment_id}",
+    response_model=AssignmentDetail,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": AuthErrorResponse},
+        status.HTTP_403_FORBIDDEN: {"model": AuthErrorResponse},
+        status.HTTP_404_NOT_FOUND: {"model": AuthErrorResponse},
+    },
+)
+def get_course_assignment(
+    course_id: UUID,
+    assignment_id: UUID,
+    _: Annotated[
+        object,
+        Depends(require_course_capability(CourseCapability.MANAGE_COURSE)),
+    ],
+    assessment_service: Annotated[AssessmentService, Depends(get_assessment_service)],
+) -> AssignmentDetail:
+    """Fetch a single assignment detail within a managed course.
+
+    Args:
+        course_id: Course identifier from the route path.
+        assignment_id: Assignment identifier from the route path.
+        _: Authenticated capability-gated session context.
+        assessment_service: Assessment service used to load the assignment.
+
+    Returns:
+        AssignmentDetail: Assignment detail payload scoped to the course.
+    """
+    assignment = _get_course_scoped_assignment(
+        course_id=course_id,
+        assignment_id=assignment_id,
+        assessment_service=assessment_service,
+    )
+    return AssignmentDetail.from_domain(assignment)
+
+
+@router.patch(
+    "/courses/{course_id}/assignments/{assignment_id}",
+    response_model=AssignmentDetail,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {"model": AuthErrorResponse},
+        status.HTTP_401_UNAUTHORIZED: {"model": AuthErrorResponse},
+        status.HTTP_403_FORBIDDEN: {"model": AuthErrorResponse},
+        status.HTTP_404_NOT_FOUND: {"model": AuthErrorResponse},
+    },
+)
+def update_course_assignment(
+    course_id: UUID,
+    assignment_id: UUID,
+    payload: UpdateAssignmentInput,
+    _: Annotated[
+        object,
+        Depends(require_course_capability(CourseCapability.MANAGE_COURSE)),
+    ],
+    assessment_service: Annotated[AssessmentService, Depends(get_assessment_service)],
+) -> AssignmentDetail:
+    """Update a managed course assignment.
+
+    Args:
+        course_id: Course identifier from the route path.
+        assignment_id: Assignment identifier from the route path.
+        payload: Editable assignment fields to update.
+        _: Authenticated capability-gated session context.
+        assessment_service: Assessment service used to persist the update.
+
+    Returns:
+        AssignmentDetail: Updated assignment payload.
+
+    Raises:
+        HTTPException: If the assignment is missing, outside the course, or invalid.
+    """
+    _get_course_scoped_assignment(
+        course_id=course_id,
+        assignment_id=assignment_id,
+        assessment_service=assessment_service,
+    )
+
+    try:
+        updated_assignment = assessment_service.update_assignment(
+            assignment_id=assignment_id,
+            title=payload.title,
+            description=payload.description,
+            assignment_type=payload.assignment_type,
+            publish_state=payload.publish_state,
+        )
+    except InvalidAssessmentDataError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return AssignmentDetail.from_domain(updated_assignment)
+
+
+def _get_course_scoped_assignment(
+    *,
+    course_id: UUID,
+    assignment_id: UUID,
+    assessment_service: AssessmentService,
+) -> Assignment:
+    """Resolve an assignment and verify it belongs to the requested course.
+
+    Args:
+        course_id: Course identifier from the route path.
+        assignment_id: Assignment identifier from the route path.
+        assessment_service: Assessment service used to load the assignment.
+
+    Returns:
+        Assignment: Resolved assignment entity.
+
+    Raises:
+        HTTPException: If the assignment does not exist for the given course.
+    """
+    try:
+        assignment = assessment_service.get_assignment(assignment_id)
+    except EntityNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
+    if assignment.course_id != course_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"assignment {assignment_id} was not found in course {course_id}",
+        )
+
+    return assignment

--- a/backend/packages/contracts/src/optimark_clio/__init__.py
+++ b/backend/packages/contracts/src/optimark_clio/__init__.py
@@ -14,6 +14,7 @@ from optimark_clio.assessment import (
     AssignmentDetail,
     AssignmentSummary,
     AssignmentVersionRecord,
+    CreateCourseAssignmentInput,
     CreateAssignmentInput,
     CreateAssignmentVersionInput,
     CreateSubmissionInput,
@@ -22,6 +23,7 @@ from optimark_clio.assessment import (
     RecordEvaluationInput,
     RecordGradeInput,
     SubmissionRecord,
+    UpdateAssignmentInput,
 )
 from optimark_clio.auth import (
     AuthErrorResponse,
@@ -42,6 +44,7 @@ __all__ = [
     "CreateAssignmentInput",
     "CreateAssignmentVersionInput",
     "CreateCourseInput",
+    "CreateCourseAssignmentInput",
     "CreateSubmissionInput",
     "CreateUserInput",
     "EnrollmentRecord",
@@ -56,6 +59,7 @@ __all__ = [
     "SessionUser",
     "SignupRequest",
     "SubmissionRecord",
+    "UpdateAssignmentInput",
     "UserDetail",
     "UserSummary",
     "WorkerBootstrapMessage",

--- a/backend/packages/contracts/src/optimark_clio/assessment.py
+++ b/backend/packages/contracts/src/optimark_clio/assessment.py
@@ -33,6 +33,24 @@ class CreateAssignmentInput(BaseModel):
     publish_state: AssignmentPublishState = AssignmentPublishState.DRAFT
 
 
+class CreateCourseAssignmentInput(BaseModel):
+    """Input payload for creating a managed course assignment."""
+
+    title: str
+    description: str
+    assignment_type: AssignmentType
+    publish_state: AssignmentPublishState = AssignmentPublishState.DRAFT
+
+
+class UpdateAssignmentInput(BaseModel):
+    """Input payload for updating editable assignment fields."""
+
+    title: str | None = None
+    description: str | None = None
+    assignment_type: AssignmentType | None = None
+    publish_state: AssignmentPublishState | None = None
+
+
 class AssignmentSummary(BaseModel):
     """Summary representation of an assignment."""
 

--- a/backend/packages/db/src/optimark_mnemosyne/assessment_repository.py
+++ b/backend/packages/db/src/optimark_mnemosyne/assessment_repository.py
@@ -83,6 +83,27 @@ class SqlAlchemyAssessmentRepository:
             _assignment_from_model(model) for model in self._session.scalars(statement)
         ]
 
+    def update_assignment(
+        self,
+        *,
+        assignment_id: UUID,
+        title: str,
+        description: str,
+        assignment_type: AssignmentType,
+        publish_state: AssignmentPublishState,
+    ) -> Assignment:
+        """Persist updates to an existing assignment record."""
+        model = self._session.get(AssignmentModel, assignment_id)
+        if model is None:
+            raise LookupError(f"assignment {assignment_id} was not found")
+
+        model.title = title
+        model.description = description
+        model.assignment_type = assignment_type
+        model.publish_state = publish_state
+        self._session.flush()
+        return _assignment_from_model(model)
+
     def add_assignment_version(
         self,
         *,

--- a/backend/packages/domain/src/optimark_metis/assessment_repository.py
+++ b/backend/packages/domain/src/optimark_metis/assessment_repository.py
@@ -41,6 +41,17 @@ class AssessmentRepository(Protocol):
     def list_course_assignments(self, course_id: UUID) -> Sequence[Assignment]:
         """List assignments for a course."""
 
+    def update_assignment(
+        self,
+        *,
+        assignment_id: UUID,
+        title: str,
+        description: str,
+        assignment_type: AssignmentType,
+        publish_state: AssignmentPublishState,
+    ) -> Assignment:
+        """Persist updates to an existing assignment."""
+
     def add_assignment_version(
         self,
         *,

--- a/backend/packages/domain/src/optimark_metis/assessment_service.py
+++ b/backend/packages/domain/src/optimark_metis/assessment_service.py
@@ -78,6 +78,62 @@ class AssessmentService:
         self._academic_service.get_course(course_id)
         return list(self._repository.list_course_assignments(course_id))
 
+    def update_assignment(
+        self,
+        *,
+        assignment_id: UUID,
+        title: str | None = None,
+        description: str | None = None,
+        assignment_type: AssignmentType | None = None,
+        publish_state: AssignmentPublishState | None = None,
+    ) -> Assignment:
+        """Update editable fields for an assignment.
+
+        Args:
+            assignment_id: Assignment identifier to update.
+            title: Optional replacement title.
+            description: Optional replacement description.
+            assignment_type: Optional replacement assignment type.
+            publish_state: Optional replacement publish state.
+
+        Returns:
+            Assignment: Updated assignment entity.
+
+        Raises:
+            EntityNotFoundError: If the assignment does not exist.
+            InvalidAssessmentDataError: If no updates are provided or any string is blank.
+        """
+        assignment = self.get_assignment(assignment_id)
+
+        normalized_title = (
+            self._normalize_required(value=title, field_name="title")
+            if title is not None
+            else assignment.title
+        )
+        normalized_description = (
+            self._normalize_required(value=description, field_name="description")
+            if description is not None
+            else assignment.description
+        )
+        next_assignment_type = assignment_type or assignment.assignment_type
+        next_publish_state = publish_state or assignment.publish_state
+
+        if (
+            normalized_title == assignment.title
+            and normalized_description == assignment.description
+            and next_assignment_type is assignment.assignment_type
+            and next_publish_state is assignment.publish_state
+        ):
+            raise InvalidAssessmentDataError("at least one assignment field must change")
+
+        return self._repository.update_assignment(
+            assignment_id=assignment.id,
+            title=normalized_title,
+            description=normalized_description,
+            assignment_type=next_assignment_type,
+            publish_state=next_publish_state,
+        )
+
     def create_assignment_version(
         self,
         *,

--- a/backend/tests/test_api_management.py
+++ b/backend/tests/test_api_management.py
@@ -1,0 +1,226 @@
+"""API tests for instructor course and assignment management routes."""
+
+from fastapi.testclient import TestClient
+
+from optimark_metis.academic import CourseRole
+from optimark_metis.assessment import AssignmentPublishState, AssignmentType
+
+
+def test_list_managed_courses_returns_only_instructor_courses(
+    api_client: TestClient,
+    auth_service,
+    academic_service,
+) -> None:
+    """Verify the managed-courses endpoint returns instructor-owned courses.
+
+    Args:
+        api_client: FastAPI test client bound to the shared test database.
+        auth_service: Auth service used to issue test sessions.
+        academic_service: Academic service used to seed course memberships.
+    """
+    unauthenticated = api_client.get("/api/v1/courses/managed")
+    assert unauthenticated.status_code == 401
+
+    issued_session = auth_service.signup(
+        email="instructor-manager@example.edu",
+        display_name="Instructor Manager",
+        password="super-secure-pass",
+    )
+    managed_course = academic_service.create_course(
+        course_code="CS 5501",
+        title="Advanced Algorithms",
+        term="Fall 2028",
+    )
+    observed_course = academic_service.create_course(
+        course_code="CS 5502",
+        title="Distributed Systems",
+        term="Fall 2028",
+    )
+    academic_service.enroll_user(
+        course_id=managed_course.id,
+        user_id=issued_session.authentication.user.id,
+        role=CourseRole.INSTRUCTOR,
+    )
+    academic_service.enroll_user(
+        course_id=observed_course.id,
+        user_id=issued_session.authentication.user.id,
+        role=CourseRole.STUDENT,
+    )
+
+    api_client.cookies.set("optimark_session", issued_session.token)
+    response = api_client.get("/api/v1/courses/managed")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": str(managed_course.id),
+            "course_code": "CS 5501",
+            "title": "Advanced Algorithms",
+            "term": "Fall 2028",
+        },
+    ]
+
+
+def test_course_assignment_management_routes_support_crud(
+    api_client: TestClient,
+    auth_service,
+    academic_service,
+) -> None:
+    """Verify instructors can create, list, fetch, and update assignments.
+
+    Args:
+        api_client: FastAPI test client bound to the shared test database.
+        auth_service: Auth service used to issue test sessions.
+        academic_service: Academic service used to seed course memberships.
+    """
+    issued_session = auth_service.signup(
+        email="instructor-assignment@example.edu",
+        display_name="Assignment Instructor",
+        password="super-secure-pass",
+    )
+    course = academic_service.create_course(
+        course_code="CS 6601",
+        title="Program Analysis",
+        term="Spring 2029",
+    )
+    academic_service.enroll_user(
+        course_id=course.id,
+        user_id=issued_session.authentication.user.id,
+        role=CourseRole.INSTRUCTOR,
+    )
+    api_client.cookies.set("optimark_session", issued_session.token)
+
+    create_response = api_client.post(
+        f"/api/v1/courses/{course.id}/assignments",
+        json={
+            "title": "Escape Analysis Lab",
+            "description": "Implement baseline escape analysis.",
+            "assignment_type": AssignmentType.CODING.value,
+            "publish_state": AssignmentPublishState.DRAFT.value,
+        },
+    )
+
+    assert create_response.status_code == 201
+    created_assignment = create_response.json()
+    assignment_id = created_assignment["id"]
+    assert created_assignment["course_id"] == str(course.id)
+    assert created_assignment["title"] == "Escape Analysis Lab"
+
+    list_response = api_client.get(f"/api/v1/courses/{course.id}/assignments")
+    assert list_response.status_code == 200
+    assert list_response.json() == [
+        {
+            "id": assignment_id,
+            "course_id": str(course.id),
+            "title": "Escape Analysis Lab",
+            "assignment_type": AssignmentType.CODING.value,
+            "publish_state": AssignmentPublishState.DRAFT.value,
+        },
+    ]
+
+    detail_response = api_client.get(
+        f"/api/v1/courses/{course.id}/assignments/{assignment_id}",
+    )
+    assert detail_response.status_code == 200
+    assert detail_response.json()["description"] == (
+        "Implement baseline escape analysis."
+    )
+
+    update_response = api_client.patch(
+        f"/api/v1/courses/{course.id}/assignments/{assignment_id}",
+        json={
+            "title": "Interprocedural Escape Analysis Lab",
+            "publish_state": AssignmentPublishState.PUBLISHED.value,
+        },
+    )
+    assert update_response.status_code == 200
+    updated_assignment = update_response.json()
+    assert updated_assignment["title"] == "Interprocedural Escape Analysis Lab"
+    assert updated_assignment["publish_state"] == (
+        AssignmentPublishState.PUBLISHED.value
+    )
+    assert updated_assignment["description"] == "Implement baseline escape analysis."
+
+
+def test_course_assignment_management_routes_enforce_permissions_and_scope(
+    api_client: TestClient,
+    db_session,
+    auth_service,
+    academic_service,
+    assessment_service,
+) -> None:
+    """Verify management routes reject unauthorized and out-of-scope access.
+
+    Args:
+        api_client: FastAPI test client bound to the shared test database.
+        auth_service: Auth service used to issue test sessions.
+        academic_service: Academic service used to seed course memberships.
+        assessment_service: Assessment service used to seed assignment records.
+    """
+    instructor_session = auth_service.signup(
+        email="course-owner@example.edu",
+        display_name="Course Owner",
+        password="super-secure-pass",
+    )
+    student_session = auth_service.signup(
+        email="learner@example.edu",
+        display_name="Learner",
+        password="super-secure-pass",
+    )
+    managed_course = academic_service.create_course(
+        course_code="CS 7701",
+        title="Compiler Construction",
+        term="Summer 2029",
+    )
+    other_course = academic_service.create_course(
+        course_code="CS 7702",
+        title="Machine Learning Systems",
+        term="Summer 2029",
+    )
+    academic_service.enroll_user(
+        course_id=managed_course.id,
+        user_id=instructor_session.authentication.user.id,
+        role=CourseRole.INSTRUCTOR,
+    )
+    academic_service.enroll_user(
+        course_id=other_course.id,
+        user_id=instructor_session.authentication.user.id,
+        role=CourseRole.INSTRUCTOR,
+    )
+    academic_service.enroll_user(
+        course_id=managed_course.id,
+        user_id=student_session.authentication.user.id,
+        role=CourseRole.STUDENT,
+    )
+    assignment = assessment_service.create_assignment(
+        course_id=managed_course.id,
+        title="SSA Lab",
+        description="Build an SSA transformer.",
+        assignment_type=AssignmentType.CODING,
+        publish_state=AssignmentPublishState.DRAFT,
+    )
+    db_session.commit()
+
+    unauthenticated = api_client.get(
+        f"/api/v1/courses/{managed_course.id}/assignments",
+    )
+    assert unauthenticated.status_code == 401
+
+    api_client.cookies.set("optimark_session", student_session.token)
+    forbidden = api_client.get(f"/api/v1/courses/{managed_course.id}/assignments")
+    assert forbidden.status_code == 403
+
+    api_client.cookies.set("optimark_session", instructor_session.token)
+    wrong_scope = api_client.get(
+        f"/api/v1/courses/{other_course.id}/assignments/{assignment.id}",
+    )
+    assert wrong_scope.status_code == 404
+
+    invalid_update = api_client.patch(
+        f"/api/v1/courses/{managed_course.id}/assignments/{assignment.id}",
+        json={},
+    )
+    assert invalid_update.status_code == 400
+    assert invalid_update.json() == {
+        "detail": "at least one assignment field must change",
+    }

--- a/backend/tests/test_assessment_service.py
+++ b/backend/tests/test_assessment_service.py
@@ -135,6 +135,36 @@ def test_assessment_service_rejects_duplicate_assignment_version_numbers(
         )
 
 
+def test_assessment_service_updates_assignments(
+    assessment_service: AssessmentService,
+    academic_service,
+) -> None:
+    """Update editable assignment fields for a managed assignment."""
+    course = academic_service.create_course(
+        course_code="CS150",
+        title="Programming Languages",
+        term="Spring 2027",
+    )
+    assignment = assessment_service.create_assignment(
+        course_id=course.id,
+        title="Interpreter Lab",
+        description="Build the first evaluator pass.",
+        assignment_type=AssignmentType.CODING,
+    )
+
+    updated_assignment = assessment_service.update_assignment(
+        assignment_id=assignment.id,
+        title="Interpreter Project",
+        description="Build the evaluator and parser passes.",
+        publish_state=AssignmentPublishState.PUBLISHED,
+    )
+
+    assert updated_assignment.id == assignment.id
+    assert updated_assignment.title == "Interpreter Project"
+    assert updated_assignment.description == "Build the evaluator and parser passes."
+    assert updated_assignment.publish_state is AssignmentPublishState.PUBLISHED
+
+
 def test_assessment_service_rejects_mismatched_submission_and_scores(
     assessment_service: AssessmentService,
     academic_service,

--- a/frontend/apps/apollo/src/features/assignments/AssignmentBuilderPage.tsx
+++ b/frontend/apps/apollo/src/features/assignments/AssignmentBuilderPage.tsx
@@ -1,6 +1,11 @@
-import { FileCode2, FolderOpen, Sparkles, Upload } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { CircleAlert, FileCode2, FolderOpen, LoaderCircle, Sparkles } from "lucide-react";
 import {
   BottomActionBar,
+  EmptyState,
   FormFieldScaffold,
   PageHeader,
   PageShell,
@@ -9,93 +14,353 @@ import {
   SurfacePanel,
 } from "@optimark/calliope";
 
-import { starterFiles } from "./mock-data";
+import {
+  assignmentDetailQueryKey,
+  createAssignment,
+  fetchAssignmentDetail,
+  fetchManagedCourses,
+  managedAssignmentsQueryKey,
+  managedCoursesQueryKey,
+  sanitizeCourseId,
+  updateAssignment,
+  type AssignmentPublishState,
+  type AssignmentType,
+} from "./api";
 
-export function AssignmentBuilderPage() {
+type AssignmentBuilderPageProps = {
+  mode: "create" | "edit";
+  assignmentId?: string;
+  courseId?: string;
+};
+
+type AssignmentFormState = {
+  title: string;
+  description: string;
+  assignmentType: AssignmentType;
+  publishState: AssignmentPublishState;
+};
+
+const INITIAL_FORM_STATE: AssignmentFormState = {
+  title: "",
+  description: "",
+  assignmentType: "coding",
+  publishState: "draft",
+};
+
+export function AssignmentBuilderPage({
+  mode,
+  assignmentId,
+  courseId,
+}: AssignmentBuilderPageProps) {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [formState, setFormState] = useState<AssignmentFormState>(INITIAL_FORM_STATE);
+  const normalizedCourseId = sanitizeCourseId(courseId);
+
+  const coursesQuery = useQuery({
+    queryKey: managedCoursesQueryKey,
+    queryFn: fetchManagedCourses,
+  });
+
+  const selectedCourseId = useMemo(
+    () => normalizedCourseId ?? coursesQuery.data?.[0]?.id,
+    [coursesQuery.data, normalizedCourseId],
+  );
+
+  const selectedCourse =
+    coursesQuery.data?.find((course) => course.id === selectedCourseId) ?? null;
+
+  const assignmentDetailQuery = useQuery({
+    queryKey:
+      mode === "edit" && selectedCourseId && assignmentId
+        ? assignmentDetailQueryKey(selectedCourseId, assignmentId)
+        : ["instructor", "assignments", "editor", "unselected"],
+    queryFn: () => fetchAssignmentDetail(selectedCourseId!, assignmentId!),
+    enabled: mode === "edit" && Boolean(selectedCourseId) && Boolean(assignmentId),
+  });
+
+  useEffect(() => {
+    if (mode === "edit" && assignmentDetailQuery.data) {
+      setFormState({
+        title: assignmentDetailQuery.data.title,
+        description: assignmentDetailQuery.data.description,
+        assignmentType: assignmentDetailQuery.data.assignmentType,
+        publishState: assignmentDetailQuery.data.publishState,
+      });
+      return;
+    }
+
+    if (mode === "create") {
+      setFormState(INITIAL_FORM_STATE);
+    }
+  }, [assignmentDetailQuery.data, mode]);
+
+  useEffect(() => {
+    if (selectedCourseId && selectedCourseId !== normalizedCourseId) {
+      void navigate({
+        to: ".",
+        search: { course: selectedCourseId },
+        replace: true,
+      });
+    }
+  }, [navigate, normalizedCourseId, selectedCourseId]);
+
+  useEffect(() => {
+    if (selectedCourseId && selectedCourseId !== normalizedCourseId) {
+      void navigate({
+        to: ".",
+        search: { course: selectedCourseId },
+        replace: true,
+      });
+    }
+  }, [navigate, normalizedCourseId, selectedCourseId]);
+
+  const assignmentMutation = useMutation({
+    mutationFn: async (nextState: AssignmentFormState) => {
+      if (!selectedCourseId) {
+        throw new Error("Select a managed course before saving an assignment.");
+      }
+
+      if (mode === "edit" && assignmentId) {
+        return updateAssignment(selectedCourseId, assignmentId, nextState);
+      }
+
+      return createAssignment(selectedCourseId, nextState);
+    },
+    onSuccess: async (assignment) => {
+      if (!selectedCourseId) {
+        return;
+      }
+
+      await queryClient.invalidateQueries({
+        queryKey: managedAssignmentsQueryKey(selectedCourseId),
+      });
+      queryClient.setQueryData(
+        assignmentDetailQueryKey(selectedCourseId, assignment.id),
+        assignment,
+      );
+      await navigate({
+        to: "/assignments/$assignmentId",
+        params: { assignmentId: assignment.id },
+        search: { course: selectedCourseId },
+        replace: mode === "edit",
+      });
+    },
+  });
+
+  const isLoading =
+    coursesQuery.isLoading || (mode === "edit" && assignmentDetailQuery.isLoading);
+  const loadError =
+    coursesQuery.error instanceof Error
+      ? coursesQuery.error
+      : assignmentDetailQuery.error instanceof Error
+        ? assignmentDetailQuery.error
+        : null;
+
+  const editorTitle =
+    mode === "edit" ? formState.title || "Edit Assignment" : "Create Assignment";
+
+  const submitWithState = (publishState: AssignmentPublishState) => {
+    assignmentMutation.mutate({
+      ...formState,
+      publishState,
+    });
+  };
+
+  const handleCourseChange = (nextCourseId: string) => {
+    if (mode === "edit" && assignmentId) {
+      void navigate({
+        to: "/assignments/$assignmentId",
+        params: { assignmentId },
+        search: { course: nextCourseId },
+      });
+      return;
+    }
+
+    void navigate({
+      to: "/assignments/new",
+      search: { course: nextCourseId },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <PageShell>
+        <PageHeader eyebrow="Assignment Editor" title="Loading assignment workspace" />
+        <SurfacePanel className="app-panel-state">
+          <LoaderCircle size={18} className="app-spin" />
+          <span>Preparing the assignment editor...</span>
+        </SurfacePanel>
+      </PageShell>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <PageShell>
+        <PageHeader eyebrow="Assignment Editor" title="We hit a loading problem" />
+        <SurfacePanel className="app-panel-state app-panel-state-error">
+          <CircleAlert size={18} />
+          <span>{loadError.message}</span>
+        </SurfacePanel>
+      </PageShell>
+    );
+  }
+
+  if (!selectedCourseId || !selectedCourse) {
+    return (
+      <PageShell>
+        <PageHeader
+          eyebrow="Assignment Editor"
+          title="No managed course selected"
+          subtitle="Choose one of your managed courses before creating assignments."
+        />
+        <EmptyState
+          icon={<FolderOpen size={18} />}
+          title="Managed courses required"
+          description="Return to the assignments overview to pick a course context for this editor."
+          action={
+            <Link to="/assignments" search={{ course: undefined }} className="app-primary-action">
+              Back to Assignments
+            </Link>
+          }
+        />
+      </PageShell>
+    );
+  }
+
   return (
     <PageShell>
-      <PageHeader eyebrow="Assignment Editor" title="Homework 4: Linked Lists" />
+      <PageHeader
+        eyebrow={mode === "edit" ? "Edit Assignment" : "Create Assignment"}
+        title={editorTitle}
+        subtitle={`${selectedCourse.courseCode} • ${selectedCourse.title}`}
+      />
 
       <div className="app-editor-grid">
         <div className="app-editor-main">
           <SectionHeading
             icon={<FileCode2 size={16} />}
-            title="Description"
+            title="Assignment Brief"
             actions={
               <div className="app-inline-group">
-                <button className="app-inline-action app-inline-action-active" type="button">
-                  Write
-                </button>
-                <button className="app-inline-action" type="button">
-                  Preview
-                </button>
+                <Link
+                  to="/assignments"
+                  search={{ course: selectedCourseId }}
+                  className="app-inline-control"
+                >
+                  Back to List
+                </Link>
               </div>
             }
           />
 
-          <SurfacePanel muted className="app-editor-block">
-            <pre>{`## Instructions
-Implement a singly linked list with the following methods:
-- append(value)
-- prepend(value)
-- delete(value)
-- find(value)
+          <SurfacePanel muted className="app-editor-block app-form-stack">
+            <FormFieldScaffold label="Title">
+              <input
+                className="app-form-input"
+                value={formState.title}
+                onChange={(event) =>
+                  setFormState((current) => ({
+                    ...current,
+                    title: event.target.value,
+                  }))
+                }
+                placeholder="Homework 4: Linked Lists"
+              />
+            </FormFieldScaffold>
 
-### Constraints
-- Time Complexity: O(n) for searching
-- Space Complexity: O(1) for deletions
-
-Ensure all edge cases are handled (empty list, single node list).`}</pre>
+            <FormFieldScaffold label="Description" support="Markdown-friendly prompt text">
+              <textarea
+                className="app-form-textarea"
+                value={formState.description}
+                onChange={(event) =>
+                  setFormState((current) => ({
+                    ...current,
+                    description: event.target.value,
+                  }))
+                }
+                placeholder="Describe the assignment requirements, starter assumptions, and expected output."
+              />
+            </FormFieldScaffold>
           </SurfacePanel>
 
-          <SectionHeading icon={<FolderOpen size={16} />} title="Starter Files" />
-          <div className="app-file-stack">
-            {starterFiles.map((file) => (
-              <SurfacePanel key={file.name} muted className="app-file-row">
-                <div className="app-file-main">
-                  <div className="app-file-icon">{file.icon}</div>
-                  <div>
-                    <strong>{file.name}</strong>
-                    <p>{file.meta}</p>
-                  </div>
-                </div>
-              </SurfacePanel>
-            ))}
-            <div className="app-upload-zone">
-              <Upload size={18} />
-              Upload Additional Files
-            </div>
-          </div>
+          <SurfacePanel muted className="app-editor-callout">
+            <strong>Course-linked editor</strong>
+            <p>
+              This editor now saves directly against the selected managed course.
+              File attachments, version snapshots, and richer publishing controls can
+              layer in later without changing the route or course-selection model.
+            </p>
+          </SurfacePanel>
         </div>
 
         <SurfacePanel muted className="app-editor-inspector">
           <SectionHeading title="Metadata" />
           <div className="app-inspector-grid">
-            <FormFieldScaffold label="Due Date">
-              <div className="app-field-value">Oct 15, 2026</div>
+            <FormFieldScaffold label="Course">
+              <select
+                className="app-form-input"
+                value={selectedCourseId}
+                onChange={(event) => handleCourseChange(event.target.value)}
+                disabled={mode === "edit"}
+              >
+                {coursesQuery.data?.map((course) => (
+                  <option key={course.id} value={course.id}>
+                    {course.courseCode} • {course.title}
+                  </option>
+                ))}
+              </select>
             </FormFieldScaffold>
-            <FormFieldScaffold label="Points">
-              <div className="app-field-value">100</div>
+
+            <FormFieldScaffold label="Assignment Type">
+              <select
+                className="app-form-input"
+                value={formState.assignmentType}
+                onChange={(event) =>
+                  setFormState((current) => ({
+                    ...current,
+                    assignmentType: event.target.value as AssignmentType,
+                  }))
+                }
+              >
+                <option value="coding">Coding</option>
+                <option value="document">Document</option>
+                <option value="quiz">Quiz</option>
+              </select>
             </FormFieldScaffold>
-            <FormFieldScaffold label="Language">
-              <div className="app-field-value">Python 3.10</div>
-            </FormFieldScaffold>
-            <FormFieldScaffold label="Submission Limit" support="3 attempts">
-              <div className="app-slider-track">
-                <span />
-              </div>
+
+            <FormFieldScaffold label="Publish State">
+              <select
+                className="app-form-input"
+                value={formState.publishState}
+                onChange={(event) =>
+                  setFormState((current) => ({
+                    ...current,
+                    publishState: event.target.value as AssignmentPublishState,
+                  }))
+                }
+              >
+                <option value="draft">Draft</option>
+                <option value="published">Published</option>
+                <option value="archived">Archived</option>
+              </select>
             </FormFieldScaffold>
           </div>
+
           <div className="app-inspector-meta">
             <div className="app-meta-row">
               <span>Visibility</span>
-              <StatusPill>Hidden</StatusPill>
+              <StatusPill tone={formState.publishState === "published" ? "primary" : "default"}>
+                {formState.publishState}
+              </StatusPill>
             </div>
             <div className="app-meta-row">
               <span>Category</span>
-              <StatusPill tone="primary">Coding</StatusPill>
+              <StatusPill tone="primary">{formState.assignmentType}</StatusPill>
             </div>
           </div>
+
           <button className="app-verify-card" type="button">
             <Sparkles size={22} />
             Verify Environment
@@ -107,13 +372,40 @@ Ensure all edge cases are handled (empty list, single node list).`}</pre>
         leading={
           <div className="app-status-cluster">
             <span className="app-smallcaps">Current Status</span>
-            <strong>Draft Saving...</strong>
+            <strong>
+              {assignmentMutation.isPending
+                ? "Saving..."
+                : mode === "edit"
+                  ? "Editing existing assignment"
+                  : "Create a new assignment"}
+            </strong>
           </div>
         }
         actions={
           <>
-            <button className="app-inline-action" type="button">Save Draft</button>
-            <button className="app-primary-action" type="button">Publish</button>
+            {assignmentMutation.isError ? (
+              <span className="app-inline-error">
+                {assignmentMutation.error instanceof Error
+                  ? assignmentMutation.error.message
+                  : "Could not save the assignment."}
+              </span>
+            ) : null}
+            <button
+              className="app-inline-action"
+              type="button"
+              onClick={() => submitWithState("draft")}
+              disabled={assignmentMutation.isPending}
+            >
+              Save Draft
+            </button>
+            <button
+              className="app-primary-action"
+              type="button"
+              onClick={() => submitWithState("published")}
+              disabled={assignmentMutation.isPending}
+            >
+              {assignmentMutation.isPending ? "Saving..." : "Publish"}
+            </button>
           </>
         }
       />

--- a/frontend/apps/apollo/src/features/assignments/AssignmentsPage.tsx
+++ b/frontend/apps/apollo/src/features/assignments/AssignmentsPage.tsx
@@ -1,25 +1,256 @@
-import { Link } from "@tanstack/react-router";
-import { FolderOpen } from "lucide-react";
-import { EmptyState, PageHeader, PageShell } from "@optimark/calliope";
+import { useEffect, useMemo } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { BookOpen, CircleAlert, FilePlus2, LoaderCircle } from "lucide-react";
+import { EmptyState, PageHeader, PageShell, SectionHeading, StatusPill, SurfacePanel } from "@optimark/calliope";
+
+import {
+  fetchCourseAssignments,
+  fetchManagedCourses,
+  managedAssignmentsQueryKey,
+  managedCoursesQueryKey,
+  sanitizeCourseId,
+  type AssignmentPublishState,
+  type ManagedCourse,
+} from "./api";
+import { assignmentsRoute } from "../../routes/assignments";
+
+function formatAssignmentDate(value: string) {
+  if (!value) {
+    return "Recently updated";
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return "Recently updated";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(parsed);
+}
+
+function assignmentTone(
+  publishState: AssignmentPublishState,
+): "default" | "primary" | "secondary" | "danger" {
+  switch (publishState) {
+    case "published":
+      return "primary";
+    case "archived":
+      return "secondary";
+    case "draft":
+    default:
+      return "default";
+  }
+}
+
+function courseLabel(course: ManagedCourse) {
+  return `${course.courseCode} • ${course.term}`;
+}
 
 export function AssignmentsPage() {
+  const navigate = useNavigate({ from: assignmentsRoute.fullPath });
+  const search = assignmentsRoute.useSearch();
+  const {
+    data: courses,
+    isLoading: coursesLoading,
+    isError: coursesError,
+    error: coursesErrorValue,
+  } = useQuery({
+    queryKey: managedCoursesQueryKey,
+    queryFn: fetchManagedCourses,
+  });
+
+  const selectedCourseId = useMemo(
+    () => sanitizeCourseId(search.course) ?? courses?.[0]?.id,
+    [courses, search.course],
+  );
+  const selectedCourse = courses?.find((course) => course.id === selectedCourseId) ?? null;
+
+  useEffect(() => {
+    if (selectedCourseId && selectedCourseId !== search.course) {
+      void navigate({
+        to: "/assignments",
+        search: { course: selectedCourseId },
+        replace: true,
+      });
+    }
+  }, [navigate, search.course, selectedCourseId]);
+
+  const assignmentsQuery = useQuery({
+    queryKey: selectedCourseId
+      ? managedAssignmentsQueryKey(selectedCourseId)
+      : ["instructor", "courses", "unselected", "assignments"],
+    queryFn: () => fetchCourseAssignments(selectedCourseId!),
+    enabled: Boolean(selectedCourseId),
+  });
+
   return (
     <PageShell>
       <PageHeader
-        eyebrow="Foundation Surface"
-        title="Assignment workflows"
-        subtitle="The design system now supports calm inspector layouts, file rails, and editorial form treatment for future instructor flows."
+        eyebrow="Instructor Management"
+        title="Assignments"
+        subtitle={
+          selectedCourse
+            ? `Manage coursework for ${selectedCourse.title} without leaving the protected workspace.`
+            : "Select one of your managed courses to create and edit assignments."
+        }
         actions={
-          <Link to="/assignments/new" className="app-primary-action">
-            Open Editor
+          <Link
+            to="/assignments/new"
+            search={{ course: selectedCourseId }}
+            className="app-primary-action"
+          >
+            <FilePlus2 size={16} />
+            New Assignment
           </Link>
         }
       />
-      <EmptyState
-        icon={<FolderOpen size={18} />}
-        title="Reusable assignment patterns are ready"
-        description="Issue #8 can plug actual assignment data and actions into this shared shell without restyling the workspace."
-      />
+
+      <div className="app-management-grid">
+        <SurfacePanel muted className="app-course-rail">
+          <SectionHeading icon={<BookOpen size={16} />} title="Managed Courses" />
+
+          {coursesLoading ? (
+            <div className="app-panel-state">
+              <LoaderCircle size={18} className="app-spin" />
+              <span>Loading your course roster...</span>
+            </div>
+          ) : null}
+
+          {coursesError ? (
+            <div className="app-panel-state app-panel-state-error">
+              <CircleAlert size={18} />
+              <span>{coursesErrorValue instanceof Error ? coursesErrorValue.message : "Could not load courses."}</span>
+            </div>
+          ) : null}
+
+          {!coursesLoading && !coursesError ? (
+            <div className="app-course-stack">
+              {courses?.map((course) => {
+                const active = course.id === selectedCourseId;
+
+                return (
+                  <button
+                    key={course.id}
+                    type="button"
+                    className={`app-course-card ${active ? "app-course-card-active" : ""}`.trim()}
+                    onClick={() => {
+                      void navigate({
+                        to: "/assignments",
+                        search: { course: course.id },
+                      });
+                    }}
+                  >
+                    <span className="app-smallcaps">{course.courseCode}</span>
+                    <strong>{course.title}</strong>
+                    <p>{course.term}</p>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+        </SurfacePanel>
+
+        <SurfacePanel className="app-assignment-table-panel">
+          <SectionHeading
+            title={selectedCourse ? selectedCourse.title : "Course Assignments"}
+            actions={selectedCourse ? <span className="app-smallcaps">{courseLabel(selectedCourse)}</span> : null}
+          />
+
+          {!selectedCourseId && !coursesLoading ? (
+            <EmptyState
+              icon={<BookOpen size={18} />}
+              title="No managed courses yet"
+              description="Once your instructor enrollments are available, course-specific assignment management will appear here."
+            />
+          ) : null}
+
+          {assignmentsQuery.isLoading ? (
+            <div className="app-panel-state">
+              <LoaderCircle size={18} className="app-spin" />
+              <span>Loading assignments...</span>
+            </div>
+          ) : null}
+
+          {assignmentsQuery.isError ? (
+            <div className="app-panel-state app-panel-state-error">
+              <CircleAlert size={18} />
+              <span>{assignmentsQuery.error instanceof Error ? assignmentsQuery.error.message : "Could not load assignments."}</span>
+            </div>
+          ) : null}
+
+          {!assignmentsQuery.isLoading &&
+          !assignmentsQuery.isError &&
+          selectedCourse &&
+          assignmentsQuery.data?.length ? (
+            <table className="app-dense-table">
+              <thead>
+                <tr>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                  <th>Status</th>
+                  <th>Updated</th>
+                  <th className="align-right">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {assignmentsQuery.data.map((assignment) => (
+                  <tr key={assignment.id}>
+                    <td>
+                      <div className="app-assignment-cell">
+                        <strong className="app-table-strong">{assignment.title}</strong>
+                        <p>{assignment.description || "Add a clearer prompt in the editor."}</p>
+                      </div>
+                    </td>
+                    <td>{assignment.assignmentType}</td>
+                    <td>
+                      <StatusPill tone={assignmentTone(assignment.publishState)}>
+                        {assignment.publishState}
+                      </StatusPill>
+                    </td>
+                    <td>{formatAssignmentDate(assignment.updatedAt)}</td>
+                    <td className="align-right">
+                      <Link
+                        to="/assignments/$assignmentId"
+                        params={{ assignmentId: assignment.id }}
+                        search={{ course: selectedCourse.id }}
+                        className="app-inline-control"
+                      >
+                        Edit
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : null}
+
+          {!assignmentsQuery.isLoading &&
+          !assignmentsQuery.isError &&
+          selectedCourse &&
+          !assignmentsQuery.data?.length ? (
+            <EmptyState
+              icon={<FilePlus2 size={18} />}
+              title="No assignments in this course yet"
+              description="Create the first assignment for this course and we’ll keep the editor on the same managed-course context."
+              action={
+                <Link
+                  to="/assignments/new"
+                  search={{ course: selectedCourse.id }}
+                  className="app-primary-action"
+                >
+                  Create First Assignment
+                </Link>
+              }
+            />
+          ) : null}
+        </SurfacePanel>
+      </div>
     </PageShell>
   );
 }

--- a/frontend/apps/apollo/src/features/assignments/api.ts
+++ b/frontend/apps/apollo/src/features/assignments/api.ts
@@ -1,0 +1,176 @@
+import { requestJson } from "../../lib/api/client";
+
+export type ManagedCourse = {
+  id: string;
+  courseCode: string;
+  title: string;
+  term: string;
+};
+
+export type AssignmentType = "coding" | "document" | "quiz";
+
+export type AssignmentPublishState = "draft" | "published" | "archived";
+
+export type ManagedAssignment = {
+  id: string;
+  courseId: string;
+  title: string;
+  description: string;
+  assignmentType: AssignmentType;
+  publishState: AssignmentPublishState;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AssignmentWritePayload = {
+  title: string;
+  description: string;
+  assignmentType: AssignmentType;
+  publishState: AssignmentPublishState;
+};
+
+type RawManagedCourse = {
+  id: string;
+  course_code?: string;
+  courseCode?: string;
+  title: string;
+  term: string;
+};
+
+type RawManagedAssignment = {
+  id: string;
+  course_id?: string;
+  courseId?: string;
+  title: string;
+  description: string;
+  assignment_type?: AssignmentType;
+  assignmentType?: AssignmentType;
+  publish_state?: AssignmentPublishState;
+  publishState?: AssignmentPublishState;
+  created_at?: string;
+  createdAt?: string;
+  updated_at?: string;
+  updatedAt?: string;
+};
+
+export const managedCoursesQueryKey = ["instructor", "courses"] as const;
+
+export function managedAssignmentsQueryKey(courseId: string) {
+  return ["instructor", "courses", courseId, "assignments"] as const;
+}
+
+export function assignmentDetailQueryKey(courseId: string, assignmentId: string) {
+  return ["instructor", "courses", courseId, "assignments", assignmentId] as const;
+}
+
+function normalizeCourse(course: RawManagedCourse): ManagedCourse {
+  return {
+    id: course.id,
+    courseCode: course.courseCode ?? course.course_code ?? "Course",
+    title: course.title,
+    term: course.term,
+  };
+}
+
+function normalizeAssignment(assignment: RawManagedAssignment): ManagedAssignment {
+  return {
+    id: assignment.id,
+    courseId: assignment.courseId ?? assignment.course_id ?? "",
+    title: assignment.title,
+    description: assignment.description,
+    assignmentType: assignment.assignmentType ?? assignment.assignment_type ?? "coding",
+    publishState: assignment.publishState ?? assignment.publish_state ?? "draft",
+    createdAt: assignment.createdAt ?? assignment.created_at ?? "",
+    updatedAt: assignment.updatedAt ?? assignment.updated_at ?? "",
+  };
+}
+
+export function sanitizeCourseId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(trimmed)
+    ? trimmed
+    : undefined;
+}
+
+export async function fetchManagedCourses(): Promise<ManagedCourse[]> {
+  const courses = await requestJson<RawManagedCourse[]>("/api/v1/courses/managed", {
+    method: "GET",
+  });
+
+  return courses.map(normalizeCourse);
+}
+
+export async function fetchCourseAssignments(courseId: string): Promise<ManagedAssignment[]> {
+  const assignments = await requestJson<RawManagedAssignment[]>(
+    `/api/v1/courses/${courseId}/assignments`,
+    {
+      method: "GET",
+    },
+  );
+
+  return assignments.map(normalizeAssignment);
+}
+
+export async function fetchAssignmentDetail(
+  courseId: string,
+  assignmentId: string,
+): Promise<ManagedAssignment> {
+  const assignment = await requestJson<RawManagedAssignment>(
+    `/api/v1/courses/${courseId}/assignments/${assignmentId}`,
+    {
+      method: "GET",
+    },
+  );
+
+  return normalizeAssignment(assignment);
+}
+
+export async function createAssignment(
+  courseId: string,
+  payload: AssignmentWritePayload,
+): Promise<ManagedAssignment> {
+  const assignment = await requestJson<RawManagedAssignment>(
+    `/api/v1/courses/${courseId}/assignments`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        title: payload.title,
+        description: payload.description,
+        assignment_type: payload.assignmentType,
+        publish_state: payload.publishState,
+      }),
+    },
+  );
+
+  return normalizeAssignment(assignment);
+}
+
+export async function updateAssignment(
+  courseId: string,
+  assignmentId: string,
+  payload: AssignmentWritePayload,
+): Promise<ManagedAssignment> {
+  const assignment = await requestJson<RawManagedAssignment>(
+    `/api/v1/courses/${courseId}/assignments/${assignmentId}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({
+        title: payload.title,
+        description: payload.description,
+        assignment_type: payload.assignmentType,
+        publish_state: payload.publishState,
+      }),
+    },
+  );
+
+  return normalizeAssignment(assignment);
+}

--- a/frontend/apps/apollo/src/features/shell/AppSidebar.tsx
+++ b/frontend/apps/apollo/src/features/shell/AppSidebar.tsx
@@ -78,15 +78,23 @@ export function AppSidebar() {
           mark={<Code2 size={18} />}
         />
       }
-      navigation={navItems.map(({ to, label, icon: Icon }) => (
-        <Link key={to} to={to}>
-          {({ isActive }) => (
-            <SidebarNavItem active={isActive} icon={<Icon size={20} />} label={label} />
-          )}
-        </Link>
-      ))}
+      navigation={navItems.map(({ to, label, icon: Icon }) =>
+        to === "/assignments" ? (
+          <Link key={to} to={to} search={{ course: undefined }}>
+            {({ isActive }) => (
+              <SidebarNavItem active={isActive} icon={<Icon size={20} />} label={label} />
+            )}
+          </Link>
+        ) : (
+          <Link key={to} to={to}>
+            {({ isActive }) => (
+              <SidebarNavItem active={isActive} icon={<Icon size={20} />} label={label} />
+            )}
+          </Link>
+        ),
+      )}
       primaryAction={
-        <Link to="/assignments/new" className="app-primary-action">
+        <Link to="/assignments/new" search={{ course: undefined }} className="app-primary-action">
           New Assessment
         </Link>
       }

--- a/frontend/apps/apollo/src/routes/assignment-editor.tsx
+++ b/frontend/apps/apollo/src/routes/assignment-editor.tsx
@@ -1,10 +1,40 @@
 import { createRoute } from "@tanstack/react-router";
 
+import { sanitizeCourseId } from "../features/assignments/api";
 import { AssignmentBuilderPage } from "../features/assignments/AssignmentBuilderPage";
 import { protectedLayoutRoute } from "./protected";
 
-export const assignmentEditorRoute = createRoute({
+function NewAssignmentRouteComponent() {
+  const search = newAssignmentRoute.useSearch();
+  return <AssignmentBuilderPage mode="create" courseId={search.course} />;
+}
+
+export const newAssignmentRoute = createRoute({
   getParentRoute: () => protectedLayoutRoute,
   path: "/assignments/new",
-  component: AssignmentBuilderPage,
+  validateSearch: (search) => ({
+    course: sanitizeCourseId(search.course),
+  }),
+  component: NewAssignmentRouteComponent,
+});
+
+function EditAssignmentRouteComponent() {
+  const { assignmentId } = editAssignmentRoute.useParams();
+  const search = editAssignmentRoute.useSearch();
+  return (
+    <AssignmentBuilderPage
+      mode="edit"
+      assignmentId={assignmentId}
+      courseId={search.course}
+    />
+  );
+}
+
+export const editAssignmentRoute = createRoute({
+  getParentRoute: () => protectedLayoutRoute,
+  path: "/assignments/$assignmentId",
+  validateSearch: (search) => ({
+    course: sanitizeCourseId(search.course),
+  }),
+  component: EditAssignmentRouteComponent,
 });

--- a/frontend/apps/apollo/src/routes/assignments.tsx
+++ b/frontend/apps/apollo/src/routes/assignments.tsx
@@ -1,10 +1,14 @@
 import { createRoute } from "@tanstack/react-router";
 
+import { sanitizeCourseId } from "../features/assignments/api";
 import { AssignmentsPage } from "../features/assignments/AssignmentsPage";
 import { protectedLayoutRoute } from "./protected";
 
 export const assignmentsRoute = createRoute({
   getParentRoute: () => protectedLayoutRoute,
   path: "/assignments",
+  validateSearch: (search) => ({
+    course: sanitizeCourseId(search.course),
+  }),
   component: AssignmentsPage,
 });

--- a/frontend/apps/apollo/src/routes/router.tsx
+++ b/frontend/apps/apollo/src/routes/router.tsx
@@ -2,7 +2,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { createRoute, createRouter, redirect } from "@tanstack/react-router";
 
 import { ensureSession } from "../features/auth/session";
-import { assignmentEditorRoute } from "./assignment-editor";
+import { editAssignmentRoute, newAssignmentRoute } from "./assignment-editor";
 import { assignmentsRoute } from "./assignments";
 import { authLayoutRoute, loginRoute, signupRoute } from "./auth";
 import { dashboardRoute } from "./dashboard";
@@ -30,7 +30,8 @@ const routeTree = rootRoute.addChildren([
   protectedLayoutRoute.addChildren([
     dashboardRoute,
     assignmentsRoute,
-    assignmentEditorRoute,
+    newAssignmentRoute,
+    editAssignmentRoute,
     submissionsRoute,
     gradebookRoute,
     studentsRoute,

--- a/frontend/apps/apollo/src/styles.css
+++ b/frontend/apps/apollo/src/styles.css
@@ -331,11 +331,19 @@
   gap: 1.4rem;
 }
 
+.app-management-grid {
+  display: grid;
+  grid-template-columns: minmax(16rem, 0.75fr) minmax(0, 1.8fr);
+  gap: 1.4rem;
+}
+
 .app-table-panel,
 .app-feed-panel,
 .app-overview-card,
 .app-chart-panel,
 .app-gradebook-table-panel,
+.app-course-rail,
+.app-assignment-table-panel,
 .app-editor-block,
 .app-editor-inspector,
 .app-settings-panel {
@@ -475,6 +483,55 @@
   gap: 0.9rem;
 }
 
+.app-course-stack,
+.app-form-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.app-course-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 1rem 1rem 1.05rem;
+  border-radius: 1rem;
+  background: rgba(241, 244, 243, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(171, 180, 179, 0.16);
+  transition: transform 140ms ease, box-shadow 140ms ease, background 140ms ease;
+}
+
+.app-course-card:hover {
+  transform: translateY(-1px);
+}
+
+.app-course-card strong {
+  font-size: 0.98rem;
+}
+
+.app-course-card p {
+  margin: 0;
+  color: var(--calliope-text-muted);
+  font-size: 0.85rem;
+}
+
+.app-course-card-active {
+  background: rgba(182, 235, 254, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(33, 89, 105, 0.18);
+}
+
+.app-panel-state {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  color: var(--calliope-text-muted);
+}
+
+.app-panel-state-error {
+  color: var(--calliope-error);
+}
+
 .app-file-row {
   display: flex;
   align-items: center;
@@ -489,6 +546,36 @@
 .app-file-main strong {
   display: block;
   font-size: 1rem;
+}
+
+.app-assignment-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+}
+
+.app-assignment-cell p {
+  margin: 0;
+  color: var(--calliope-text-muted);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.app-editor-callout {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 1.25rem 1.4rem;
+}
+
+.app-editor-callout strong {
+  font-size: 0.95rem;
+}
+
+.app-editor-callout p {
+  margin: 0;
+  color: var(--calliope-text-muted);
+  line-height: 1.7;
 }
 
 .app-file-icon {
@@ -536,6 +623,35 @@
   border-radius: 0.8rem;
   background: rgba(255, 255, 255, 0.72);
   box-shadow: inset 0 0 0 1px rgba(171, 180, 179, 0.16);
+}
+
+.app-form-input,
+.app-form-textarea {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: inset 0 0 0 1px rgba(171, 180, 179, 0.16);
+  color: var(--calliope-text);
+}
+
+.app-form-input {
+  min-height: 3rem;
+  padding: 0.8rem 1rem;
+}
+
+.app-form-textarea {
+  min-height: 14rem;
+  padding: 1rem;
+  resize: vertical;
+  font: inherit;
+  line-height: 1.7;
+}
+
+.app-form-input:focus,
+.app-form-textarea:focus {
+  box-shadow: inset 0 0 0 1px var(--calliope-primary);
 }
 
 .app-slider-track {


### PR DESCRIPTION
## Summary
- add instructor course and assignment management API routes
- support managed-course assignment list, create, detail, and update flows
- wire Apollo assignment views and editor to the real backend management endpoints

## Verification
- cd backend && uv run --frozen ruff check .
- cd backend && uv run --frozen pytest
- cd frontend/apps/apollo && bun run check
- cd frontend && bun run build
- make ci
- git diff --check