### PR TITLE
fix(frontend): tighten auth redirect and logout flows

### DIFF
--- a/frontend/apps/apollo/src/features/auth/api.ts
+++ b/frontend/apps/apollo/src/features/auth/api.ts
@@ -30,6 +30,10 @@ export async function logoutRequest(): Promise<void> {
     credentials: "include",
   });
 
+  if (response.ok || response.status === 401) {
+    return;
+  }
+
   if (!response.ok) {
     throw new ApiError(response.status, "Unable to end the current session.");
   }

--- a/frontend/apps/apollo/src/features/auth/session.ts
+++ b/frontend/apps/apollo/src/features/auth/session.ts
@@ -19,6 +19,12 @@ export type SessionResponse = {
   expires_at: string;
 };
 
+type RedirectLocation = {
+  pathname: string;
+  searchStr?: string;
+  hash?: string;
+};
+
 export const sessionQueryKey = ["auth", "session"] as const;
 
 export async function fetchSession(): Promise<SessionResponse | null> {
@@ -91,6 +97,10 @@ export function deriveInitials(displayName: string): string {
     .join("")
     .slice(0, 2)
     .toUpperCase();
+}
+
+export function buildRedirectPath(location: RedirectLocation): string {
+  return `${location.pathname}${location.searchStr ?? ""}${location.hash ?? ""}`;
 }
 
 export async function ensureSession(queryClient: QueryClient): Promise<SessionResponse | null> {

--- a/frontend/apps/apollo/src/routes/protected.tsx
+++ b/frontend/apps/apollo/src/routes/protected.tsx
@@ -1,6 +1,6 @@
 import { createRoute } from "@tanstack/react-router";
 
-import { requireAuthenticated } from "../features/auth/session";
+import { buildRedirectPath, requireAuthenticated } from "../features/auth/session";
 import { ProtectedAppLayout } from "../features/shell/ProtectedAppLayout";
 import { rootRoute } from "./root";
 
@@ -8,7 +8,7 @@ export const protectedLayoutRoute = createRoute({
   getParentRoute: () => rootRoute,
   id: "protected-layout",
   beforeLoad: async ({ context, location }) => {
-    await requireAuthenticated(context.queryClient, location.pathname);
+    await requireAuthenticated(context.queryClient, buildRedirectPath(location));
   },
   component: ProtectedAppLayout,
 });


### PR DESCRIPTION
## Summary
- make protected-route redirects preserve the full intended destination
- treat logout as successful when the server reports an already-invalid session so client state still clears cleanly
- keep the changes aligned with the existing TanStack Router and React Query auth flow

## Testing
- `bun run check` in `/Users/thomasorth/optimark/frontend` on the source workspace

## Context
- follow-up cleanup for the frontend auth flow from #27