### PR TITLE
feat: define coding artifact handoff contract

### DIFF
--- a/backend/packages/contracts/src/optimark_clio/__init__.py
+++ b/backend/packages/contracts/src/optimark_clio/__init__.py
@@ -45,6 +45,14 @@ from optimark_clio.coding_runner import (
     CodingRunnerTestcaseResult,
     CodingRunnerTestcaseStatus,
 )
+from optimark_clio.coding_handoff import (
+    CodingBundleEntry,
+    CodingBundleEntryKind,
+    CodingExecutionArtifactSet,
+    CodingExecutionHandoff,
+    CodingHandoffMode,
+    CodingHandoffPackagingVersion,
+)
 from optimark_clio.auth import (
     AuthErrorResponse,
     LoginRequest,
@@ -61,6 +69,12 @@ __all__ = [
     "AuthErrorResponse",
     "CourseDetail",
     "CourseSummary",
+    "CodingBundleEntry",
+    "CodingBundleEntryKind",
+    "CodingExecutionArtifactSet",
+    "CodingExecutionHandoff",
+    "CodingHandoffMode",
+    "CodingHandoffPackagingVersion",
     "CodingRunnerArtifactRef",
     "CodingRunnerArtifactRole",
     "CodingRunnerExecutionLimits",

--- a/backend/packages/contracts/src/optimark_clio/coding_handoff.py
+++ b/backend/packages/contracts/src/optimark_clio/coding_handoff.py
@@ -1,0 +1,96 @@
+"""Shared contracts for coding artifact packaging and execution handoff."""
+
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+from optimark_clio.coding_runner import CodingRunnerArtifactRef
+
+
+class CodingHandoffMode(StrEnum):
+    """How the worker presents artifacts to an execution environment."""
+
+    REFERENCE_MANIFEST = "reference_manifest"
+    PREPARED_BUNDLE = "prepared_bundle"
+
+
+class CodingHandoffPackagingVersion(StrEnum):
+    """Version marker for the packaging contract itself."""
+
+    V1 = "v1"
+
+
+class CodingBundleEntryKind(StrEnum):
+    """Normalized entry kinds inside a prepared execution bundle."""
+
+    SUBMISSION_ROOT = "submission_root"
+    ASSIGNMENT_SUPPORT = "assignment_support"
+    GRADER_SUPPORT = "grader_support"
+    WORKSPACE_MANIFEST = "workspace_manifest"
+
+
+class CodingBundleEntry(BaseModel):
+    """How one source artifact is materialized inside a prepared bundle."""
+
+    source_artifact: CodingRunnerArtifactRef
+    entry_kind: CodingBundleEntryKind
+    relative_path: str
+    required: bool = True
+    extraction_mode: str = "as_provided"
+
+
+class CodingExecutionArtifactSet(BaseModel):
+    """Normalized artifact set required to stage a coding execution run."""
+
+    submission_artifact: CodingRunnerArtifactRef
+    assignment_artifacts: list[CodingRunnerArtifactRef] = Field(default_factory=list)
+    grader_artifacts: list[CodingRunnerArtifactRef] = Field(default_factory=list)
+
+
+class CodingExecutionHandoff(BaseModel):
+    """Stable handoff manifest from orchestration into execution preparation."""
+
+    handoff_id: UUID
+    run_id: UUID
+    assignment_id: UUID
+    assignment_version_id: UUID
+    submission_id: UUID
+    created_at: datetime
+    packaging_version: CodingHandoffPackagingVersion = CodingHandoffPackagingVersion.V1
+    mode: CodingHandoffMode
+    artifacts: CodingExecutionArtifactSet
+    staging_key_prefix: str
+    manifest_artifact: CodingRunnerArtifactRef | None = None
+    prepared_bundle_artifact: CodingRunnerArtifactRef | None = None
+    bundle_entries: list[CodingBundleEntry] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_mode_specific_fields(self) -> "CodingExecutionHandoff":
+        """Ensure required fields are present for the selected handoff mode."""
+        if self.mode is CodingHandoffMode.REFERENCE_MANIFEST:
+            if self.manifest_artifact is None:
+                raise ValueError(
+                    "manifest_artifact is required when mode is reference_manifest",
+                )
+            if self.prepared_bundle_artifact is not None:
+                raise ValueError(
+                    "prepared_bundle_artifact must be omitted when mode is reference_manifest",
+                )
+            if self.bundle_entries:
+                raise ValueError(
+                    "bundle_entries must be empty when mode is reference_manifest",
+                )
+
+        if self.mode is CodingHandoffMode.PREPARED_BUNDLE:
+            if self.prepared_bundle_artifact is None:
+                raise ValueError(
+                    "prepared_bundle_artifact is required when mode is prepared_bundle",
+                )
+            if not self.bundle_entries:
+                raise ValueError(
+                    "bundle_entries are required when mode is prepared_bundle",
+                )
+
+        return self

--- a/backend/packages/contracts/src/optimark_clio/coding_handoff.py
+++ b/backend/packages/contracts/src/optimark_clio/coding_handoff.py
@@ -88,6 +88,10 @@ class CodingExecutionHandoff(BaseModel):
                 raise ValueError(
                     "prepared_bundle_artifact is required when mode is prepared_bundle",
                 )
+            if self.manifest_artifact is not None:
+                raise ValueError(
+                    "manifest_artifact must be omitted when mode is prepared_bundle",
+                )
             if not self.bundle_entries:
                 raise ValueError(
                     "bundle_entries are required when mode is prepared_bundle",

--- a/backend/tests/test_coding_handoff_contracts.py
+++ b/backend/tests/test_coding_handoff_contracts.py
@@ -1,0 +1,120 @@
+"""Tests for the coding artifact packaging and handoff schemas."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from optimark_clio import (
+    CodingBundleEntry,
+    CodingBundleEntryKind,
+    CodingExecutionArtifactSet,
+    CodingExecutionHandoff,
+    CodingHandoffMode,
+    CodingRunnerArtifactRef,
+    CodingRunnerArtifactRole,
+)
+
+
+def _artifact(role: CodingRunnerArtifactRole, uri: str, name: str) -> CodingRunnerArtifactRef:
+    return CodingRunnerArtifactRef(
+        role=role,
+        reference_uri=uri,
+        display_name=name,
+    )
+
+
+def test_reference_manifest_handoff_requires_manifest_artifact() -> None:
+    """Verify the reference-only handoff mode carries a manifest artifact."""
+    submission_artifact = _artifact(
+        CodingRunnerArtifactRole.SUBMISSION,
+        "s3://optimark-dev/submissions/submission.zip",
+        "submission.zip",
+    )
+    handoff = CodingExecutionHandoff(
+        handoff_id=uuid4(),
+        run_id=uuid4(),
+        assignment_id=uuid4(),
+        assignment_version_id=uuid4(),
+        submission_id=uuid4(),
+        created_at=datetime(2026, 5, 9, 14, 0, tzinfo=UTC),
+        mode=CodingHandoffMode.REFERENCE_MANIFEST,
+        artifacts=CodingExecutionArtifactSet(submission_artifact=submission_artifact),
+        staging_key_prefix="runs/123/",
+        manifest_artifact=_artifact(
+            CodingRunnerArtifactRole.RESULT_BUNDLE,
+            "s3://optimark-dev/runs/123/handoff-manifest.json",
+            "handoff-manifest.json",
+        ),
+    )
+
+    assert handoff.mode is CodingHandoffMode.REFERENCE_MANIFEST
+    assert handoff.manifest_artifact is not None
+    assert handoff.prepared_bundle_artifact is None
+
+
+def test_prepared_bundle_handoff_requires_bundle_and_entries() -> None:
+    """Verify prepared bundles declare both the bundle and its entry mapping."""
+    submission_artifact = _artifact(
+        CodingRunnerArtifactRole.SUBMISSION,
+        "s3://optimark-dev/submissions/submission.zip",
+        "submission.zip",
+    )
+    prepared_bundle = _artifact(
+        CodingRunnerArtifactRole.RESULT_BUNDLE,
+        "s3://optimark-dev/runs/123/workspace.tar.gz",
+        "workspace.tar.gz",
+    )
+    handoff = CodingExecutionHandoff(
+        handoff_id=uuid4(),
+        run_id=uuid4(),
+        assignment_id=uuid4(),
+        assignment_version_id=uuid4(),
+        submission_id=uuid4(),
+        created_at=datetime(2026, 5, 9, 14, 0, tzinfo=UTC),
+        mode=CodingHandoffMode.PREPARED_BUNDLE,
+        artifacts=CodingExecutionArtifactSet(submission_artifact=submission_artifact),
+        staging_key_prefix="runs/123/",
+        prepared_bundle_artifact=prepared_bundle,
+        bundle_entries=[
+            CodingBundleEntry(
+                source_artifact=submission_artifact,
+                entry_kind=CodingBundleEntryKind.SUBMISSION_ROOT,
+                relative_path="workspace/submission/",
+            ),
+        ],
+    )
+
+    assert handoff.prepared_bundle_artifact == prepared_bundle
+    assert handoff.bundle_entries[0].relative_path == "workspace/submission/"
+
+
+def test_handoff_mode_specific_validation_rejects_ambiguous_combinations() -> None:
+    """Verify handoff manifests reject incompatible packaging combinations."""
+    submission_artifact = _artifact(
+        CodingRunnerArtifactRole.SUBMISSION,
+        "s3://optimark-dev/submissions/submission.zip",
+        "submission.zip",
+    )
+    common_kwargs = {
+        "handoff_id": uuid4(),
+        "run_id": uuid4(),
+        "assignment_id": uuid4(),
+        "assignment_version_id": uuid4(),
+        "submission_id": uuid4(),
+        "created_at": datetime(2026, 5, 9, 14, 0, tzinfo=UTC),
+        "artifacts": CodingExecutionArtifactSet(submission_artifact=submission_artifact),
+        "staging_key_prefix": "runs/123/",
+    }
+
+    with pytest.raises(ValueError, match="manifest_artifact is required"):
+        CodingExecutionHandoff(
+            mode=CodingHandoffMode.REFERENCE_MANIFEST,
+            **common_kwargs,
+        )
+
+    with pytest.raises(ValueError, match="prepared_bundle_artifact is required"):
+        CodingExecutionHandoff(
+            mode=CodingHandoffMode.PREPARED_BUNDLE,
+            **common_kwargs,
+        )

--- a/backend/tests/test_coding_handoff_contracts.py
+++ b/backend/tests/test_coding_handoff_contracts.py
@@ -118,3 +118,26 @@ def test_handoff_mode_specific_validation_rejects_ambiguous_combinations() -> No
             mode=CodingHandoffMode.PREPARED_BUNDLE,
             **common_kwargs,
         )
+
+    with pytest.raises(ValueError, match="manifest_artifact must be omitted"):
+        CodingExecutionHandoff(
+            mode=CodingHandoffMode.PREPARED_BUNDLE,
+            prepared_bundle_artifact=_artifact(
+                CodingRunnerArtifactRole.RESULT_BUNDLE,
+                "s3://optimark-dev/runs/123/workspace.tar.gz",
+                "workspace.tar.gz",
+            ),
+            manifest_artifact=_artifact(
+                CodingRunnerArtifactRole.RESULT_BUNDLE,
+                "s3://optimark-dev/runs/123/handoff-manifest.json",
+                "handoff-manifest.json",
+            ),
+            bundle_entries=[
+                CodingBundleEntry(
+                    source_artifact=submission_artifact,
+                    entry_kind=CodingBundleEntryKind.SUBMISSION_ROOT,
+                    relative_path="workspace/submission/",
+                ),
+            ],
+            **common_kwargs,
+        )

--- a/docs/adr/0009-artifact-packaging-and-execution-handoff.md
+++ b/docs/adr/0009-artifact-packaging-and-execution-handoff.md
@@ -1,0 +1,118 @@
+# ADR-0009: Artifact Packaging and Execution Handoff for Coding Runs
+
+- Status: Accepted
+- Date: 2026-05-09
+
+## Context
+ADR-0008 defined the stable runner request and result contract, but it intentionally left one critical boundary open: how submission artifacts, assignment support assets, and grader inputs are prepared for execution.
+
+The product now has:
+- versioned assignments
+- persisted submission artifacts
+- a runner request that references artifacts by URI
+
+The next implementation milestone is orchestration in issue `#10`. That worker-side flow needs more than a runner request. It also needs a stable handoff model that explains:
+- which artifacts participate in a run
+- how those artifacts are grouped for execution preparation
+- whether execution consumes references directly or a prepared workspace bundle
+- how the application records that handoff without choosing the final sandbox transport
+
+Without that packaging model, `#10` would be forced to embed storage-specific staging assumptions or runner-specific workspace conventions into the worker logic.
+
+## Decision
+Optimark will define a stable execution handoff manifest that sits between orchestration and the runner-facing execution environment.
+
+The shared packaging and handoff contracts are represented at:
+- [coding_handoff.py](../../backend/packages/contracts/src/optimark_clio/coding_handoff.py)
+
+### Artifact types in a coding run
+The artifact set for an MVP coding run consists of:
+- one required submission artifact:
+  - the student-uploaded source artifact for a specific `submission_id`
+- zero or more assignment support artifacts:
+  - starter files
+  - hidden tests
+  - fixtures
+  - instructor-authored data files tied to an `assignment_version_id`
+- zero or more grader support artifacts:
+  - grader entrypoints
+  - harness code
+  - reference assets required by the grading implementation
+- optional execution output artifacts:
+  - logs
+  - result bundles
+  - feedback reports
+
+These artifact categories remain orthogonal to the final transport or staging strategy.
+
+### Handoff modes
+The contract supports two packaging modes:
+
+1. `reference_manifest`
+   - orchestration produces a manifest artifact plus an artifact-set record
+   - the downstream execution layer resolves artifact URIs itself
+   - this is the least opinionated mode and keeps storage references first-class
+
+2. `prepared_bundle`
+   - orchestration produces a prepared workspace bundle plus an explicit mapping of source artifacts to relative bundle paths
+   - the downstream execution layer consumes one packaged workspace artifact instead of resolving each source reference independently
+
+Both modes share the same top-level handoff envelope so the worker can evolve from reference-first staging to prepared bundles without changing the external orchestration contract.
+
+### Stable handoff manifest
+Every execution handoff must include:
+- `handoff_id`
+- `run_id`
+- `assignment_id`
+- `assignment_version_id`
+- `submission_id`
+- `created_at`
+- `packaging_version`
+- `mode`
+- the normalized input artifact set
+- a `staging_key_prefix`
+
+Mode-specific fields:
+- `reference_manifest` requires `manifest_artifact`
+- `prepared_bundle` requires `prepared_bundle_artifact` and `bundle_entries`
+
+### Bundle entry semantics
+Prepared bundles must declare how source artifacts are materialized into the execution workspace. Each bundle entry records:
+- the source artifact reference
+- the normalized entry kind
+- the relative workspace path
+- whether the source is required
+- the extraction/materialization mode
+
+This keeps bundle layout decisions explicit and auditable instead of hidden inside a worker implementation.
+
+### Versioning semantics
+Assignment versioning and submission identity are part of the handoff contract, not incidental metadata:
+- `assignment_version_id` identifies the exact versioned assignment context for hidden tests, starter assets, and grader inputs
+- `submission_id` identifies the exact student artifact chosen for execution
+- `run_id` identifies the execution attempt that consumed those inputs
+
+This makes reruns and future review workflows easier to reason about because artifact provenance is carried directly by the handoff manifest.
+
+## Consequences
+### Positive
+- Gives issue `#10` a stable staging contract for worker orchestration.
+- Keeps artifact grouping and bundle layout explicit without choosing a final sandbox runtime.
+- Preserves assignment-version and submission provenance through the handoff boundary.
+- Supports a low-commitment reference-first implementation while leaving room for prepared bundle optimization later.
+
+### Negative
+- Adds one more contract layer between orchestration and execution.
+- Some implementation details, like archive extraction policy and staging retention, remain intentionally unresolved.
+
+### Follow-on implications
+- Issue `#10` should persist an execution handoff record or equivalent manifest reference alongside autograde run state.
+- Issue `#13` runner requests should consume artifact refs derived from this handoff contract rather than bypassing it.
+- Issue `#16` can choose the eventual isolation/scaling strategy without redefining the packaging envelope.
+
+## Explicit Non-Decisions
+This ADR does not decide:
+- whether prepared bundles are tarballs, zip archives, mounted directories, or another format
+- whether references are resolved from object storage, local disk mirrors, or another backing store
+- the final sandbox transport between worker and execution runtime
+- the long-term retention policy for staged workspaces or intermediate artifacts

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ This directory contains the formal Architecture Decision Records (ADRs) for Opti
 - [ADR-0006: Frontend Bun Workspace Package Topology](./0006-frontend-bun-workspace-package-topology.md)
 - [ADR-0007: Backend uv Workspace Package Topology](./0007-backend-uv-workspace-package-topology.md)
 - [ADR-0008: Runner Contract for Coding Submissions](./0008-runner-contract-for-coding-submissions.md)
+- [ADR-0009: Artifact Packaging and Execution Handoff for Coding Runs](./0009-artifact-packaging-and-execution-handoff.md)
 
 ## Usage
 - Create a new ADR when making a meaningful architectural or product-platform decision.

--- a/docs/optimark-ai-spec.md
+++ b/docs/optimark-ai-spec.md
@@ -278,6 +278,7 @@ This is intentionally constrained. The product must define the contract and life
 - error semantics
 - lifecycle integration points
 - persistence model for run status and results
+- artifact grouping and execution handoff semantics
 
 ### Must not define yet
 - Docker vs Firecracker vs VM vs other isolation choice
@@ -295,6 +296,7 @@ The future coding runner interface must support:
 - runtime version
 - grading configuration reference
 - execution limits
+- artifact handoff manifest or prepared bundle source
 
 ### Outputs
 - normalized status


### PR DESCRIPTION
## Summary
- add shared coding artifact handoff contracts for reference-manifest and prepared-bundle execution modes
- add tests covering mode-specific validation and bundle-entry semantics
- establish the artifact packaging and execution handoff ADR for issue #14

## Testing
- backend/.venv/bin/pytest backend/tests/test_coding_handoff_contracts.py backend/tests/test_coding_runner_contracts.py backend/tests/test_api_management.py backend/tests/test_api_submissions.py backend/tests/test_api_auth.py backend/tests/test_api_config.py
- python -m compileall backend/packages/contracts/src/optimark_clio

Closes #14
