### PR TITLE
feat: define grading semantics for reruns and grade release

### DIFF
--- a/backend/packages/contracts/src/optimark_clio/__init__.py
+++ b/backend/packages/contracts/src/optimark_clio/__init__.py
@@ -53,6 +53,15 @@ from optimark_clio.coding_handoff import (
     CodingHandoffMode,
     CodingHandoffPackagingVersion,
 )
+from optimark_clio.coding_grading import (
+    CodingGradeAuthority,
+    CodingGradeDecisionSnapshot,
+    CodingGradeReleaseState,
+    CodingReviewState,
+    CodingRerunOutcome,
+    CodingRerunPolicy,
+    CodingRerunScenario,
+)
 from optimark_clio.auth import (
     AuthErrorResponse,
     LoginRequest,
@@ -73,8 +82,15 @@ __all__ = [
     "CodingBundleEntryKind",
     "CodingExecutionArtifactSet",
     "CodingExecutionHandoff",
+    "CodingGradeAuthority",
+    "CodingGradeDecisionSnapshot",
+    "CodingGradeReleaseState",
     "CodingHandoffMode",
     "CodingHandoffPackagingVersion",
+    "CodingReviewState",
+    "CodingRerunOutcome",
+    "CodingRerunPolicy",
+    "CodingRerunScenario",
     "CodingRunnerArtifactRef",
     "CodingRunnerArtifactRole",
     "CodingRunnerExecutionLimits",

--- a/backend/packages/contracts/src/optimark_clio/coding_grading.py
+++ b/backend/packages/contracts/src/optimark_clio/coding_grading.py
@@ -1,0 +1,102 @@
+"""Shared contracts for coding-grade authority, reruns, and release semantics."""
+
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class CodingGradeAuthority(StrEnum):
+    """Authoritative source categories for a coding grade decision."""
+
+    AUTOGRADE = "autograde"
+    REVIEW_ADJUSTMENT = "review_adjustment"
+    MANUAL_OVERRIDE = "manual_override"
+
+
+class CodingReviewState(StrEnum):
+    """Staff-side review state for a coding submission."""
+
+    PENDING_AUTOGRADE = "pending_autograde"
+    READY_FOR_REVIEW = "ready_for_review"
+    REVIEWED = "reviewed"
+    OVERRIDDEN = "overridden"
+
+
+class CodingGradeReleaseState(StrEnum):
+    """Student visibility state for the authoritative grade."""
+
+    UNRELEASED = "unreleased"
+    RELEASED = "released"
+
+
+class CodingRerunScenario(StrEnum):
+    """Product scenarios that determine how reruns affect grade authority."""
+
+    PRE_RELEASE_UNREVIEWED = "pre_release_unreviewed"
+    PRE_RELEASE_REVIEWED = "pre_release_reviewed"
+    POST_RELEASE = "post_release"
+
+
+class CodingRerunOutcome(StrEnum):
+    """Normalized outcomes for how a rerun affects grade semantics."""
+
+    REPLACE_CANDIDATE_ONLY = "replace_candidate_only"
+    REQUIRE_REVIEW_RECONCILIATION = "require_review_reconciliation"
+    PRESERVE_RELEASED_GRADE = "preserve_released_grade"
+
+
+class CodingGradeDecisionSnapshot(BaseModel):
+    """Snapshot of the current authoritative and student-visible grade semantics."""
+
+    submission_id: UUID
+    latest_autograde_evaluation_id: UUID | None = None
+    authoritative_grade_record_id: UUID | None = None
+    authoritative_source: CodingGradeAuthority | None = None
+    review_state: CodingReviewState
+    release_state: CodingGradeReleaseState
+    student_visible_grade_record_id: UUID | None = None
+    rerun_pending_reconciliation: bool = False
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> "CodingGradeDecisionSnapshot":
+        """Ensure the snapshot encodes coherent authority and release semantics."""
+        if self.authoritative_source is None and self.authoritative_grade_record_id is not None:
+            raise ValueError(
+                "authoritative_source is required when authoritative_grade_record_id is present",
+            )
+        if self.authoritative_source is not None and self.authoritative_grade_record_id is None:
+            raise ValueError(
+                "authoritative_grade_record_id is required when authoritative_source is present",
+            )
+        if self.review_state is CodingReviewState.OVERRIDDEN and (
+            self.authoritative_source is not CodingGradeAuthority.MANUAL_OVERRIDE
+        ):
+            raise ValueError(
+                "manual_override authority is required when review_state is overridden",
+            )
+        if self.release_state is CodingGradeReleaseState.RELEASED:
+            if self.authoritative_grade_record_id is None:
+                raise ValueError(
+                    "authoritative_grade_record_id is required when release_state is released",
+                )
+            if self.student_visible_grade_record_id is None:
+                raise ValueError(
+                    "student_visible_grade_record_id is required when release_state is released",
+                )
+            if self.student_visible_grade_record_id != self.authoritative_grade_record_id:
+                raise ValueError(
+                    "student_visible_grade_record_id must match authoritative_grade_record_id when released",
+                )
+        return self
+
+
+class CodingRerunPolicy(BaseModel):
+    """Normalized policy decision for how a rerun affects the grade state."""
+
+    scenario: CodingRerunScenario
+    outcome: CodingRerunOutcome
+    authoritative_grade_changes_automatically: bool
+    student_visible_grade_changes_automatically: bool
+    reviewer_action_required: bool
+    summary: str = Field(min_length=1)

--- a/backend/packages/contracts/src/optimark_clio/coding_grading.py
+++ b/backend/packages/contracts/src/optimark_clio/coding_grading.py
@@ -75,6 +75,10 @@ class CodingGradeDecisionSnapshot(BaseModel):
             raise ValueError(
                 "manual_override authority is required when review_state is overridden",
             )
+        if self.student_visible_grade_record_id is not None and self.authoritative_grade_record_id is None:
+            raise ValueError(
+                "authoritative_grade_record_id is required when student_visible_grade_record_id is present",
+            )
         if self.release_state is CodingGradeReleaseState.RELEASED:
             if self.authoritative_grade_record_id is None:
                 raise ValueError(
@@ -88,6 +92,14 @@ class CodingGradeDecisionSnapshot(BaseModel):
                 raise ValueError(
                     "student_visible_grade_record_id must match authoritative_grade_record_id when released",
                 )
+        if (
+            self.release_state is CodingGradeReleaseState.UNRELEASED
+            and self.student_visible_grade_record_id is not None
+            and self.student_visible_grade_record_id == self.authoritative_grade_record_id
+        ):
+            raise ValueError(
+                "matching student_visible_grade_record_id and authoritative_grade_record_id require release_state to be released",
+            )
         return self
 
 
@@ -100,3 +112,43 @@ class CodingRerunPolicy(BaseModel):
     student_visible_grade_changes_automatically: bool
     reviewer_action_required: bool
     summary: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> "CodingRerunPolicy":
+        """Ensure rerun-policy flags stay aligned with the documented scenario semantics."""
+        expected = {
+            CodingRerunScenario.PRE_RELEASE_UNREVIEWED: (
+                CodingRerunOutcome.REPLACE_CANDIDATE_ONLY,
+                False,
+                False,
+                False,
+            ),
+            CodingRerunScenario.PRE_RELEASE_REVIEWED: (
+                CodingRerunOutcome.REQUIRE_REVIEW_RECONCILIATION,
+                False,
+                False,
+                True,
+            ),
+            CodingRerunScenario.POST_RELEASE: (
+                CodingRerunOutcome.PRESERVE_RELEASED_GRADE,
+                False,
+                False,
+                True,
+            ),
+        }
+        (
+            expected_outcome,
+            expected_authoritative_auto,
+            expected_student_auto,
+            expected_reviewer_required,
+        ) = expected[self.scenario]
+        if (
+            self.outcome is not expected_outcome
+            or self.authoritative_grade_changes_automatically is not expected_authoritative_auto
+            or self.student_visible_grade_changes_automatically is not expected_student_auto
+            or self.reviewer_action_required is not expected_reviewer_required
+        ):
+            raise ValueError(
+                "rerun policy fields are inconsistent for the selected scenario",
+            )
+        return self

--- a/backend/tests/test_coding_grading_contracts.py
+++ b/backend/tests/test_coding_grading_contracts.py
@@ -68,6 +68,30 @@ def test_released_snapshot_rejects_missing_or_mismatched_visible_grade() -> None
         )
 
 
+def test_unreleased_snapshot_rejects_contradictory_visibility_state() -> None:
+    """Verify unreleased snapshots cannot encode released-style visibility semantics."""
+    authoritative_grade_record_id = uuid4()
+
+    with pytest.raises(ValueError, match="authoritative_grade_record_id is required"):
+        CodingGradeDecisionSnapshot(
+            submission_id=uuid4(),
+            authoritative_source=None,
+            review_state=CodingReviewState.READY_FOR_REVIEW,
+            release_state=CodingGradeReleaseState.UNRELEASED,
+            student_visible_grade_record_id=uuid4(),
+        )
+
+    with pytest.raises(ValueError, match="require release_state to be released"):
+        CodingGradeDecisionSnapshot(
+            submission_id=uuid4(),
+            authoritative_grade_record_id=authoritative_grade_record_id,
+            authoritative_source=CodingGradeAuthority.AUTOGRADE,
+            review_state=CodingReviewState.REVIEWED,
+            release_state=CodingGradeReleaseState.UNRELEASED,
+            student_visible_grade_record_id=authoritative_grade_record_id,
+        )
+
+
 def test_rerun_policy_captures_non_destructive_post_release_behavior() -> None:
     """Verify the policy contract can encode preserved released grades on rerun."""
     policy = CodingRerunPolicy(
@@ -81,3 +105,26 @@ def test_rerun_policy_captures_non_destructive_post_release_behavior() -> None:
 
     assert policy.outcome is CodingRerunOutcome.PRESERVE_RELEASED_GRADE
     assert policy.reviewer_action_required is True
+
+
+def test_rerun_policy_rejects_invalid_scenario_and_flag_combinations() -> None:
+    """Verify rerun-policy validation rejects contradictory combinations."""
+    with pytest.raises(ValueError, match="rerun policy fields are inconsistent"):
+        CodingRerunPolicy(
+            scenario=CodingRerunScenario.POST_RELEASE,
+            outcome=CodingRerunOutcome.REPLACE_CANDIDATE_ONLY,
+            authoritative_grade_changes_automatically=False,
+            student_visible_grade_changes_automatically=False,
+            reviewer_action_required=True,
+            summary="Incorrectly allow a post-release rerun to overwrite the candidate only.",
+        )
+
+    with pytest.raises(ValueError, match="rerun policy fields are inconsistent"):
+        CodingRerunPolicy(
+            scenario=CodingRerunScenario.PRE_RELEASE_REVIEWED,
+            outcome=CodingRerunOutcome.REQUIRE_REVIEW_RECONCILIATION,
+            authoritative_grade_changes_automatically=False,
+            student_visible_grade_changes_automatically=True,
+            reviewer_action_required=True,
+            summary="Incorrectly allow student-visible changes during reconciliation.",
+        )

--- a/backend/tests/test_coding_grading_contracts.py
+++ b/backend/tests/test_coding_grading_contracts.py
@@ -1,0 +1,83 @@
+"""Tests for coding-grade authority, rerun, and release semantics."""
+
+from uuid import uuid4
+
+import pytest
+
+from optimark_clio import (
+    CodingGradeAuthority,
+    CodingGradeDecisionSnapshot,
+    CodingGradeReleaseState,
+    CodingReviewState,
+    CodingRerunOutcome,
+    CodingRerunPolicy,
+    CodingRerunScenario,
+)
+
+
+def test_released_snapshot_requires_matching_authoritative_and_visible_grade() -> None:
+    """Verify released grades always point at one authoritative visible record."""
+    grade_record_id = uuid4()
+    snapshot = CodingGradeDecisionSnapshot(
+        submission_id=uuid4(),
+        latest_autograde_evaluation_id=uuid4(),
+        authoritative_grade_record_id=grade_record_id,
+        authoritative_source=CodingGradeAuthority.REVIEW_ADJUSTMENT,
+        review_state=CodingReviewState.REVIEWED,
+        release_state=CodingGradeReleaseState.RELEASED,
+        student_visible_grade_record_id=grade_record_id,
+    )
+
+    assert snapshot.release_state is CodingGradeReleaseState.RELEASED
+    assert snapshot.student_visible_grade_record_id == grade_record_id
+
+
+def test_override_state_requires_manual_override_authority() -> None:
+    """Verify override review state cannot point at non-override authority."""
+    with pytest.raises(ValueError, match="manual_override authority is required"):
+        CodingGradeDecisionSnapshot(
+            submission_id=uuid4(),
+            authoritative_grade_record_id=uuid4(),
+            authoritative_source=CodingGradeAuthority.REVIEW_ADJUSTMENT,
+            review_state=CodingReviewState.OVERRIDDEN,
+            release_state=CodingGradeReleaseState.UNRELEASED,
+        )
+
+
+def test_released_snapshot_rejects_missing_or_mismatched_visible_grade() -> None:
+    """Verify release semantics reject partial or inconsistent visibility state."""
+    authoritative_grade_record_id = uuid4()
+
+    with pytest.raises(ValueError, match="student_visible_grade_record_id is required"):
+        CodingGradeDecisionSnapshot(
+            submission_id=uuid4(),
+            authoritative_grade_record_id=authoritative_grade_record_id,
+            authoritative_source=CodingGradeAuthority.AUTOGRADE,
+            review_state=CodingReviewState.REVIEWED,
+            release_state=CodingGradeReleaseState.RELEASED,
+        )
+
+    with pytest.raises(ValueError, match="must match authoritative_grade_record_id"):
+        CodingGradeDecisionSnapshot(
+            submission_id=uuid4(),
+            authoritative_grade_record_id=authoritative_grade_record_id,
+            authoritative_source=CodingGradeAuthority.AUTOGRADE,
+            review_state=CodingReviewState.REVIEWED,
+            release_state=CodingGradeReleaseState.RELEASED,
+            student_visible_grade_record_id=uuid4(),
+        )
+
+
+def test_rerun_policy_captures_non_destructive_post_release_behavior() -> None:
+    """Verify the policy contract can encode preserved released grades on rerun."""
+    policy = CodingRerunPolicy(
+        scenario=CodingRerunScenario.POST_RELEASE,
+        outcome=CodingRerunOutcome.PRESERVE_RELEASED_GRADE,
+        authoritative_grade_changes_automatically=False,
+        student_visible_grade_changes_automatically=False,
+        reviewer_action_required=True,
+        summary="Keep the released grade visible until staff explicitly reconcile the rerun.",
+    )
+
+    assert policy.outcome is CodingRerunOutcome.PRESERVE_RELEASED_GRADE
+    assert policy.reviewer_action_required is True

--- a/docs/adr/0010-grading-semantics-for-reruns-overrides-and-release.md
+++ b/docs/adr/0010-grading-semantics-for-reruns-overrides-and-release.md
@@ -4,6 +4,7 @@
 - Date: 2026-05-09
 
 ## Context
+
 Optimark's coding-assignment workflow now has a clear submission contract and runner boundary, but the product still needs explicit grading semantics for one of the most failure-prone areas: how autograde results, manual review, reruns, overrides, and grade release interact.
 
 Without a stable semantic model, issue `#10` could persist rerun results in a way that silently changes a grade after manual review, and issue `#11` could implement review and override UX on top of ambiguous authority rules.
@@ -15,6 +16,7 @@ The key unresolved questions are:
 - how overrides relate to future autograde reruns
 
 ## Decision
+
 Optimark will separate three related but distinct concepts:
 - the latest autograde candidate result
 - the current authoritative grade decision
@@ -24,6 +26,7 @@ The shared grading-semantics contracts are represented at:
 - [coding_grading.py](../../backend/packages/contracts/src/optimark_clio/coding_grading.py)
 
 ### Authoritative source of truth
+
 `GradeRecord` remains the authoritative grading object for anything student-visible or operationally final.
 
 The authoritative grade may originate from:
@@ -34,6 +37,7 @@ The authoritative grade may originate from:
 Autograde output alone is not the final truth. It is a candidate input to a grade decision unless staff policy and workflow allow it to stand unchanged.
 
 ### Review and override semantics
+
 The coding review state is explicitly modeled as:
 - `pending_autograde`
 - `ready_for_review`
@@ -47,6 +51,7 @@ Override semantics are stricter than ordinary review adjustment:
 When the review state is `overridden`, the authoritative source must be `manual_override`.
 
 ### Release semantics
+
 Release is separate from review completion.
 
 The release-state model is:
@@ -61,6 +66,7 @@ When a grade is released:
 This means a newly completed rerun does not automatically alter student-visible state just because fresher autograde data exists.
 
 ### Rerun semantics
+
 Reruns must not silently destroy review history or mutate released grades in place.
 
 The design defines three core rerun scenarios:
@@ -87,6 +93,7 @@ The design defines three core rerun scenarios:
      - staff must explicitly reconcile and re-release if they want the rerun to supersede the published decision
 
 ### Operational interpretation
+
 These semantics imply:
 - the system may track fresher autograde candidates than the current authoritative grade
 - reruns can create "pending reconciliation" state without changing what students see
@@ -94,22 +101,27 @@ These semantics imply:
 - a superseded grade should be recorded through a new authoritative decision, not by mutating historical review intent out of existence
 
 ## Consequences
+
 ### Positive
+
 - Gives issue `#10` a safe rerun model that avoids destructive grade mutations.
 - Gives issue `#11` a clear contract for review, override, and release UX.
 - Preserves auditability by separating candidate autograde results from authoritative and student-visible grade state.
 - Keeps post-release reruns non-destructive unless staff explicitly adopt them.
 
 ### Negative
+
 - Introduces extra semantic state compared with a naive "latest run wins" model.
 - Requires reconciliation flows in later product work instead of allowing silent autograde replacement.
 
 ### Follow-on implications
+
 - Issue `#10` should persist the latest autograde candidate separately from the authoritative released grade decision.
 - Issue `#11` should expose reviewer actions that deliberately reconcile reruns rather than auto-applying them.
 - Gradebook and student-facing surfaces should distinguish unreleased candidate changes from released results.
 
 ## Explicit Non-Decisions
+
 This ADR does not decide:
 - institution-specific late-policy workflows
 - whether releases happen per submission, per assignment, or in bulk from the final gradebook UX

--- a/docs/adr/0010-grading-semantics-for-reruns-overrides-and-release.md
+++ b/docs/adr/0010-grading-semantics-for-reruns-overrides-and-release.md
@@ -1,0 +1,116 @@
+# ADR-0010: Grading Semantics for Reruns, Overrides, and Grade Release
+
+- Status: Accepted
+- Date: 2026-05-09
+
+## Context
+Optimark's coding-assignment workflow now has a clear submission contract and runner boundary, but the product still needs explicit grading semantics for one of the most failure-prone areas: how autograde results, manual review, reruns, overrides, and grade release interact.
+
+Without a stable semantic model, issue `#10` could persist rerun results in a way that silently changes a grade after manual review, and issue `#11` could implement review and override UX on top of ambiguous authority rules.
+
+The key unresolved questions are:
+- which record is authoritative before and after review
+- what a rerun is allowed to replace automatically
+- when a released grade can change student-visible state
+- how overrides relate to future autograde reruns
+
+## Decision
+Optimark will separate three related but distinct concepts:
+- the latest autograde candidate result
+- the current authoritative grade decision
+- the current student-visible released grade
+
+The shared grading-semantics contracts are represented at:
+- [coding_grading.py](../../backend/packages/contracts/src/optimark_clio/coding_grading.py)
+
+### Authoritative source of truth
+`GradeRecord` remains the authoritative grading object for anything student-visible or operationally final.
+
+The authoritative grade may originate from:
+- `autograde`
+- `review_adjustment`
+- `manual_override`
+
+Autograde output alone is not the final truth. It is a candidate input to a grade decision unless staff policy and workflow allow it to stand unchanged.
+
+### Review and override semantics
+The coding review state is explicitly modeled as:
+- `pending_autograde`
+- `ready_for_review`
+- `reviewed`
+- `overridden`
+
+Override semantics are stricter than ordinary review adjustment:
+- `reviewed` means staff accepted or adjusted the grading outcome in a normal review path
+- `overridden` means staff intentionally replaced the grading outcome with a manual decision that should not be interpreted as an ordinary autograde-derived result
+
+When the review state is `overridden`, the authoritative source must be `manual_override`.
+
+### Release semantics
+Release is separate from review completion.
+
+The release-state model is:
+- `unreleased`
+- `released`
+
+When a grade is released:
+- there must already be an authoritative `GradeRecord`
+- the student-visible grade must point to that same authoritative record
+- students continue to see the last released record until staff explicitly replace it through a new release decision
+
+This means a newly completed rerun does not automatically alter student-visible state just because fresher autograde data exists.
+
+### Rerun semantics
+Reruns must not silently destroy review history or mutate released grades in place.
+
+The design defines three core rerun scenarios:
+
+1. `pre_release_unreviewed`
+   - outcome: `replace_candidate_only`
+   - semantics:
+     - the latest autograde candidate may be replaced automatically
+     - no student-visible state changes
+     - no prior authoritative reviewed decision is being overwritten
+
+2. `pre_release_reviewed`
+   - outcome: `require_review_reconciliation`
+   - semantics:
+     - the new autograde result becomes a fresh candidate
+     - the prior authoritative grade stays authoritative until staff reconcile the rerun
+     - reviewer action is required before the authoritative grade changes
+
+3. `post_release`
+   - outcome: `preserve_released_grade`
+   - semantics:
+     - the newly completed rerun does not automatically replace the released grade
+     - the current released grade remains student-visible
+     - staff must explicitly reconcile and re-release if they want the rerun to supersede the published decision
+
+### Operational interpretation
+These semantics imply:
+- the system may track fresher autograde candidates than the current authoritative grade
+- reruns can create "pending reconciliation" state without changing what students see
+- review and release actions are explicit transitions, not side effects of autograde completion
+- a superseded grade should be recorded through a new authoritative decision, not by mutating historical review intent out of existence
+
+## Consequences
+### Positive
+- Gives issue `#10` a safe rerun model that avoids destructive grade mutations.
+- Gives issue `#11` a clear contract for review, override, and release UX.
+- Preserves auditability by separating candidate autograde results from authoritative and student-visible grade state.
+- Keeps post-release reruns non-destructive unless staff explicitly adopt them.
+
+### Negative
+- Introduces extra semantic state compared with a naive "latest run wins" model.
+- Requires reconciliation flows in later product work instead of allowing silent autograde replacement.
+
+### Follow-on implications
+- Issue `#10` should persist the latest autograde candidate separately from the authoritative released grade decision.
+- Issue `#11` should expose reviewer actions that deliberately reconcile reruns rather than auto-applying them.
+- Gradebook and student-facing surfaces should distinguish unreleased candidate changes from released results.
+
+## Explicit Non-Decisions
+This ADR does not decide:
+- institution-specific late-policy workflows
+- whether releases happen per submission, per assignment, or in bulk from the final gradebook UX
+- rubric structure or comment-thread UI details

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,6 +17,7 @@ This directory contains the formal Architecture Decision Records (ADRs) for Opti
 - [ADR-0007: Backend uv Workspace Package Topology](./0007-backend-uv-workspace-package-topology.md)
 - [ADR-0008: Runner Contract for Coding Submissions](./0008-runner-contract-for-coding-submissions.md)
 - [ADR-0009: Artifact Packaging and Execution Handoff for Coding Runs](./0009-artifact-packaging-and-execution-handoff.md)
+- [ADR-0010: Grading Semantics for Reruns, Overrides, and Grade Release](./0010-grading-semantics-for-reruns-overrides-and-release.md)
 
 ## Usage
 - Create a new ADR when making a meaningful architectural or product-platform decision.

--- a/docs/optimark-ai-spec.md
+++ b/docs/optimark-ai-spec.md
@@ -442,7 +442,7 @@ This is the recommended implementation order.
 ## 24. Open Design Threads
 These remain intentionally open and should be explored through dedicated design work:
 - artifact packaging and handoff model
-- grading semantics for reruns and release policy
+- operational workflows for reconciliation and re-release after reruns
 - isolation and scaling strategy for execution workers
 
 ## 25. Known Expansion Path

--- a/docs/optimark-ai-spec.md
+++ b/docs/optimark-ai-spec.md
@@ -320,6 +320,7 @@ These rules should guide future implementation and design work.
 3. Released grades are a distinct state from computed grades.
 4. Reruns must not silently destroy review history.
 5. Student-visible data must be separated from staff-only grading state.
+6. Post-release reruns must preserve the currently released grade until staff explicitly reconcile and re-release.
 
 ## 17. API Design Direction
 Use FastAPI OpenAPI as the source of truth and generate a typed frontend client from it.


### PR DESCRIPTION
## Summary
- add shared coding grading contracts for authoritative grade source, review state, release state, and rerun policy
- document the grading semantics in a new ADR and update the architecture index/spec guidance
- add regression coverage for released-grade and rerun-policy validation semantics

## Testing
- backend/.venv/bin/pytest backend/tests/test_coding_grading_contracts.py backend/tests/test_coding_handoff_contracts.py backend/tests/test_coding_runner_contracts.py backend/tests/test_api_management.py backend/tests/test_api_submissions.py backend/tests/test_api_auth.py backend/tests/test_api_config.py
- python -m compileall backend/packages/contracts/src/optimark_clio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Established formal grading contract types for tracking grade decisions, authority, review states, and release status
  * Implemented validation rules ensuring consistency between authoritative grades and student-visible grades
  * Added rerun policy definitions for handling grade updates across different review and release scenarios

* **Documentation**
  * Added Architecture Decision Record documenting grading semantics for reruns, overrides, and grade release
  * Updated grade specification with post-release rerun preservation requirements

* **Tests**
  * Added contract tests validating grade consistency and rerun policy behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->